### PR TITLE
Add label contour mask functionality in SuperpixelSEEDS

### DIFF
--- a/cc/modules/ximgproc/SuperpixelSEEDS.cc
+++ b/cc/modules/ximgproc/SuperpixelSEEDS.cc
@@ -19,7 +19,8 @@ NAN_MODULE_INIT(SuperpixelSEEDS::Init) {
 	Nan::SetAccessor(instanceTemplate, Nan::New("doubleStep").ToLocalChecked(), SuperpixelSEEDS::GetDoubleStep);
 	Nan::SetAccessor(instanceTemplate, Nan::New("numCalculatedSuperpixels").ToLocalChecked(), SuperpixelSEEDS::GetNumCalculatedSuperpixels);
 	Nan::SetAccessor(instanceTemplate, Nan::New("labels").ToLocalChecked(), SuperpixelSEEDS::GetLabels);
-
+	Nan::SetAccessor(instanceTemplate, Nan::New("labelContourMask").ToLocalChecked(), SuperpixelSEEDS::GetLabelContourMask);
+	
 	Nan::SetPrototypeMethod(ctor, "iterate", SuperpixelSEEDS::Iterate);
 
   target->Set(Nan::New("SuperpixelSEEDS").ToLocalChecked(), ctor->GetFunction());
@@ -70,6 +71,7 @@ NAN_METHOD(SuperpixelSEEDS::Iterate) {
 	self->superpixelSeeds->iterate(self->img, (int)iterations);
 	self->superpixelSeeds->getLabels(self->labels);
 	self->numCalculatedSuperpixels = self->superpixelSeeds->getNumberOfSuperpixels();
+	self->superpixelSeeds->getLabelContourMask(self->labelContourMask);
 }
 
 #endif // HAVE_XIMGPROC

--- a/cc/modules/ximgproc/SuperpixelSEEDS.h
+++ b/cc/modules/ximgproc/SuperpixelSEEDS.h
@@ -10,6 +10,7 @@ public:
 	cv::Ptr<cv::ximgproc::SuperpixelSEEDS> superpixelSeeds;
 	cv::Mat img;
 	cv::Mat labels;
+	cv::Mat labelContourMask;
 	int numSuperpixels;
 	int numLevels;
 	int prior = 2;
@@ -23,6 +24,7 @@ public:
 
 	static FF_GETTER_JSOBJ(SuperpixelSEEDS, GetImg, img, FF_UNWRAP_MAT_AND_GET, Mat::constructor);
 	static FF_GETTER_JSOBJ(SuperpixelSEEDS, GetLabels, labels, FF_UNWRAP_MAT_AND_GET, Mat::constructor);
+	static FF_GETTER_JSOBJ(SuperpixelSEEDS, GetLabelContourMask, labelContourMask, FF_UNWRAP_MAT_AND_GET, Mat::constructor);
 	static FF_GETTER(SuperpixelSEEDS, GetNumSuperpixels, numSuperpixels);
 	static FF_GETTER(SuperpixelSEEDS, GeNumLevels, numLevels);
 	static FF_GETTER(SuperpixelSEEDS, GetPrior, prior);


### PR DESCRIPTION
In SuperpixelSEEDS.iterate(), I just added a call to getLabelContourMask().