### PR TITLE
Support for Statical Libraries (.a files)

### DIFF
--- a/lib/utils.js
+++ b/lib/utils.js
@@ -35,6 +35,7 @@ const xmodules = [
 const libPrefixOSX = 'libopencv_';
 const libSuffixOSX = '.dylib';
 const libSuffix = process.platform === 'win32' ? '.lib' : '.so';
+const libSuffixStatic = process.platform === 'win32' ? '.lib' : '.a';
 
 const defaultDir = '/usr/local';
 const opencvDir = resolvePath(process.env.OPENCV_DIR);
@@ -82,7 +83,7 @@ const getModulesHaveHeader = () => new Promise((resolve) => {
 const getLibs = () => new Promise((resolve) => {
   fs.readdir(resolvePath(libDir), (err, files) => {
     if (err) throw(err);
-    let libsInDir = files.filter(f => f.includes(libSuffix) || f.includes(libSuffixOSX));
+    let libsInDir = files.filter(f => f.includes(libSuffix) || f.includes(libSuffixOSX) || f.includes(libSuffixStatic));
 
     if (!libsInDir.length) {
       throw new Error(`no valid .so, .lib or .dylib files found in in OPENCV_LIB_DIR ('${libDir}')`);


### PR DESCRIPTION
#113

This was a quick hack I added to allow me to build this module against a statically built opencv build.  It turns out compiling opencv with non-shared library files will produce ".a" files, but this utils function didn't search for that type of file.

There is probably a better way to implement this fix; this PR is mainly to demonstrate a solution I found.