### PR TITLE
Add mat.release() function to allow user to manually release matrix m…

### DIFF
--- a/cc/core/Mat.cc
+++ b/cc/core/Mat.cc
@@ -85,6 +85,9 @@ NAN_MODULE_INIT(Mat::Init) {
 	Nan::SetPrototypeMethod(ctor, "rotate", Rotate);
 	Nan::SetPrototypeMethod(ctor, "rotateAsync", RotateAsync);
 #endif
+
+	Nan::SetPrototypeMethod(ctor, "release", Release);
+
 	FF_PROTO_SET_MAT_OPERATIONS(ctor);
 
 	MatImgproc::Init(ctor);
@@ -1252,5 +1255,12 @@ NAN_METHOD(Mat::Row) {
 
 void Mat::setNativeProps(cv::Mat mat) {
 	this->mat = mat;
+};
+
+// free memory for this mat
+NAN_METHOD(Mat::Release) {
+    // must get pointer to the original; else we are just getting a COPY and then releasing that!
+    cv::Mat *mat = &(Nan::ObjectWrap::Unwrap<Mat>(info.This())->mat);
+    mat->release();
 };
 

--- a/cc/core/Mat.h
+++ b/cc/core/Mat.h
@@ -149,6 +149,9 @@ public:
 	static NAN_METHOD(RotateAsync);
 #endif
 
+	static NAN_METHOD(Release);
+
+
   static Nan::Persistent<v8::FunctionTemplate> constructor;
 
 	void setNativeProps(cv::Mat);


### PR DESCRIPTION
…emory

This is essential as node will use all memory quickly if the matrix objects are not released (e.g. > 6Gbytes commit size when playing a short video).
Per-cursor to adding a custom memory handler so node knows how much RAM is actually in use.

If used, this function enables memory to be kept relatively under control; still not ideal (because you have to call it!), but a start.