### PR TITLE
Add CustomAllocator for Mat.

### DIFF
--- a/binding.gyp
+++ b/binding.gyp
@@ -21,6 +21,7 @@
 			"cc/cvTypes/imgprocConstants.cc",
 			"cc/cvTypes/videoCaptureProps.cc",
 			"cc/core/core.cc",
+			"cc/core/CustomAllocator.cc",
 			"cc/core/Mat.cc",
 			"cc/core/MatImgproc.cc",
 			"cc/core/MatCalib3d.cc",

--- a/cc/core/CustomAllocator.cc
+++ b/cc/core/CustomAllocator.cc
@@ -89,7 +89,7 @@ void CustomMatAllocator::FixupJSMem() const {
     if (variables->main_thread_id == this_id){
         //std::cout << "thead is main " << this_id << "\n";
         variables->MemTotalChangeMutex.lock();
-        __int64 adjust = variables->TotalMem - variables->TotalJSMem;
+        int64_t adjust = variables->TotalMem - variables->TotalJSMem;
         variables->TotalJSMem += adjust;
         variables->MemTotalChangeMutex.unlock();
         

--- a/cc/core/CustomAllocator.cc
+++ b/cc/core/CustomAllocator.cc
@@ -3,8 +3,7 @@
 #include "CustomAllocator.h"
 //#include <iostream>
 
-// only valid for 3.1.0+
-#if CV_VERSION_MINOR > 0
+#ifdef OPENCV4NODEJS_ENABLE_EXTERNALMEMTRACKING
 
 cv::UMatData* CustomMatAllocator::allocate(int dims, const int* sizes, int type,
                        void* data0, size_t* step, int flags, cv::UMatUsageFlags usageFlags) const

--- a/cc/core/CustomAllocator.cc
+++ b/cc/core/CustomAllocator.cc
@@ -1,0 +1,96 @@
+#include "CustomAllocator.h"
+
+
+
+cv::UMatData* CustomMatAllocator::allocate(int dims, const int* sizes, int type,
+                       void* data0, size_t* step, int flags, cv::UMatUsageFlags usageFlags) const
+{
+    cv::UMatData* u = stdAllocator->allocate(dims, sizes, type, data0, step, flags, usageFlags);
+   
+    if (NULL != u){
+        u->prevAllocator = u->currAllocator = this;
+        if( !(u->flags & cv::UMatData::USER_ALLOCATED) ){
+            // make mem change atomic
+            variables->MemTotalChangeMutex.lock();
+            variables->TotalMem += u->size;
+            variables->CountMemAllocs ++;
+            variables->MemTotalChangeMutex.unlock();
+            this->FixupJSMem();
+        }
+    }
+    return u;
+}
+
+bool CustomMatAllocator::allocate(cv::UMatData* u, int accessFlags, cv::UMatUsageFlags usageFlags) const
+{
+    // this does not seem to change memory allocation?
+    return stdAllocator->allocate(u, accessFlags, usageFlags);
+}
+
+
+void CustomMatAllocator::deallocate(cv::UMatData* u) const
+{
+    if (NULL != u){
+        if( !(u->flags & cv::UMatData::USER_ALLOCATED) ){
+            // make mem change atomic
+            variables->MemTotalChangeMutex.lock();
+            variables->TotalMem -= u->size;
+            variables->CountMemDeAllocs ++;
+            variables->MemTotalChangeMutex.unlock();
+        }
+    }
+    stdAllocator->deallocate(u);
+    this->FixupJSMem();
+}
+
+
+// method to read the total mem, but mutex protected.
+__int64 CustomMatAllocator::readtotalmem(){
+    __int64 Total;
+    variables->MemTotalChangeMutex.lock();
+    Total = variables->TotalMem;
+    variables->MemTotalChangeMutex.unlock();
+    return Total;
+}
+
+__int64 CustomMatAllocator::readmeminformed(){
+    __int64 Total;
+    variables->MemTotalChangeMutex.lock();
+    Total = variables->TotalJSMem;
+    variables->MemTotalChangeMutex.unlock();
+    return Total;
+}
+
+__int64 CustomMatAllocator::readnumallocated(){
+    __int64 Total;
+    variables->MemTotalChangeMutex.lock();
+    Total = variables->CountMemAllocs;
+    variables->MemTotalChangeMutex.unlock();
+    return Total;
+}
+
+__int64 CustomMatAllocator::readnumdeallocated(){
+    __int64 Total;
+    variables->MemTotalChangeMutex.lock();
+    Total = variables->CountMemDeAllocs;
+    variables->MemTotalChangeMutex.unlock();
+    return Total;
+}
+
+
+void CustomMatAllocator::FixupJSMem() const {
+    // we can only do this IF we are on the main thread.
+    uv_thread_t me = uv_thread_self();
+    
+    if (uv_thread_equal(&(variables->main_thread), &me)){
+        variables->MemTotalChangeMutex.lock();
+        __int64 adjust = variables->TotalMem - variables->TotalJSMem;
+        variables->TotalJSMem += adjust;
+        variables->MemTotalChangeMutex.unlock();
+        
+        if (adjust){
+            Nan::AdjustExternalMemory(adjust);
+        }
+    }
+}
+

--- a/cc/core/CustomAllocator.cc
+++ b/cc/core/CustomAllocator.cc
@@ -49,32 +49,32 @@ void CustomMatAllocator::deallocate(cv::UMatData* u) const
 
 
 // method to read the total mem, but mutex protected.
-__int64 CustomMatAllocator::readtotalmem(){
-    __int64 Total;
+int64_t CustomMatAllocator::readtotalmem(){
+    int64_t Total;
     variables->MemTotalChangeMutex.lock();
     Total = variables->TotalMem;
     variables->MemTotalChangeMutex.unlock();
     return Total;
 }
 
-__int64 CustomMatAllocator::readmeminformed(){
-    __int64 Total;
+int64_t CustomMatAllocator::readmeminformed(){
+    int64_t Total;
     variables->MemTotalChangeMutex.lock();
     Total = variables->TotalJSMem;
     variables->MemTotalChangeMutex.unlock();
     return Total;
 }
 
-__int64 CustomMatAllocator::readnumallocated(){
-    __int64 Total;
+int64_t CustomMatAllocator::readnumallocated(){
+    int64_t Total;
     variables->MemTotalChangeMutex.lock();
     Total = variables->CountMemAllocs;
     variables->MemTotalChangeMutex.unlock();
     return Total;
 }
 
-__int64 CustomMatAllocator::readnumdeallocated(){
-    __int64 Total;
+int64_t CustomMatAllocator::readnumdeallocated(){
+    int64_t Total;
     variables->MemTotalChangeMutex.lock();
     Total = variables->CountMemDeAllocs;
     variables->MemTotalChangeMutex.unlock();

--- a/cc/core/CustomAllocator.cc
+++ b/cc/core/CustomAllocator.cc
@@ -1,3 +1,7 @@
+
+// only valid for 3.1.0+
+#if CV_VERSION_MINOR > 0
+
 #include "CustomAllocator.h"
 //#include <iostream>
 
@@ -102,4 +106,7 @@ void CustomMatAllocator::FixupJSMem() const {
         //std::cout << "thead not main " << this_id << "\n";
     }
 }
+
+// end only valid for 3.1.0+
+#endif
 

--- a/cc/core/CustomAllocator.cc
+++ b/cc/core/CustomAllocator.cc
@@ -1,10 +1,10 @@
 
-// only valid for 3.1.0+
-#if CV_VERSION_MINOR > 0
 
 #include "CustomAllocator.h"
 //#include <iostream>
 
+// only valid for 3.1.0+
+#if CV_VERSION_MINOR > 0
 
 cv::UMatData* CustomMatAllocator::allocate(int dims, const int* sizes, int type,
                        void* data0, size_t* step, int flags, cv::UMatUsageFlags usageFlags) const

--- a/cc/core/CustomAllocator.cc
+++ b/cc/core/CustomAllocator.cc
@@ -1,21 +1,25 @@
 #include "CustomAllocator.h"
-
+//#include <iostream>
 
 
 cv::UMatData* CustomMatAllocator::allocate(int dims, const int* sizes, int type,
                        void* data0, size_t* step, int flags, cv::UMatUsageFlags usageFlags) const
 {
     cv::UMatData* u = stdAllocator->allocate(dims, sizes, type, data0, step, flags, usageFlags);
-   
+    
     if (NULL != u){
         u->prevAllocator = u->currAllocator = this;
         if( !(u->flags & cv::UMatData::USER_ALLOCATED) ){
             // make mem change atomic
-            variables->MemTotalChangeMutex.lock();
-            variables->TotalMem += u->size;
-            variables->CountMemAllocs ++;
-            variables->MemTotalChangeMutex.unlock();
-            this->FixupJSMem();
+            try {
+                variables->MemTotalChangeMutex.lock();
+                variables->TotalMem += u->size;
+                variables->CountMemAllocs ++;
+                variables->MemTotalChangeMutex.unlock();
+                this->FixupJSMem();
+            } catch (...){
+                printf("exception adjusting memory\n");
+            }
         }
     }
     return u;
@@ -80,17 +84,22 @@ __int64 CustomMatAllocator::readnumdeallocated(){
 
 void CustomMatAllocator::FixupJSMem() const {
     // we can only do this IF we are on the main thread.
-    uv_thread_t me = uv_thread_self();
-    
-    if (uv_thread_equal(&(variables->main_thread), &me)){
+    std::thread::id this_id = std::this_thread::get_id();
+
+    if (variables->main_thread_id == this_id){
+        //std::cout << "thead is main " << this_id << "\n";
         variables->MemTotalChangeMutex.lock();
         __int64 adjust = variables->TotalMem - variables->TotalJSMem;
         variables->TotalJSMem += adjust;
         variables->MemTotalChangeMutex.unlock();
         
         if (adjust){
+            //printf("will call Nan ajust by %d\n", (int)adjust);
             Nan::AdjustExternalMemory(adjust);
+            //printf("done ajust by %d\n", (int)adjust);
         }
+    } else {
+        //std::cout << "thead not main " << this_id << "\n";
     }
 }
 

--- a/cc/core/CustomAllocator.h
+++ b/cc/core/CustomAllocator.h
@@ -1,6 +1,9 @@
 #ifndef __FF_CUSTOMALLOCATOR_H__
 #define __FF_CUSTOMALLOCATOR_H__
 
+// only valid for 3.1.0+
+#if CV_VERSION_MINOR > 0
+
 #include <thread>
 #include <stdint.h>
 
@@ -66,5 +69,8 @@ public:
     
     const cv::MatAllocator* stdAllocator;
 };
+
+// end only valid for 3.1.0+
+#endif
 
 #endif

--- a/cc/core/CustomAllocator.h
+++ b/cc/core/CustomAllocator.h
@@ -17,7 +17,14 @@
 
 // only valid for 3.1.0+
 #if CV_VERSION_MINOR > 0
+    #define OPENCV4NODEJS_ENABLE_EXTERNALMEMTRACKING 1
+#endif
 
+
+#ifdef OPENCV4NODEJS_ENABLE_EXTERNALMEMTRACKING
+
+// un-comment to enable by default
+// #define OPENCV4NODEJS_ENABLE_EXTERNALMEMTRACKING_DEFAULT_ON
 
 class CustomMatAllocator : public cv::MatAllocator
 {
@@ -49,6 +56,7 @@ public:
     }
     ~CustomMatAllocator( ) { 
         delete variables;
+        variables = NULL;
     }
 
     cv::UMatData* allocate(int dims, const int* sizes, int type,

--- a/cc/core/CustomAllocator.h
+++ b/cc/core/CustomAllocator.h
@@ -2,6 +2,7 @@
 #define __FF_CUSTOMALLOCATOR_H__
 
 #include <thread>
+#include <stdint.h>
 
 #include "Converters.h"
 #include "Size.h"
@@ -12,7 +13,6 @@
 #include "Rect.h"
 #include "RotatedRect.h"
 #include "Workers.h"
-#include "CustomAllocator.h"
 
 
 class CustomMatAllocator : public cv::MatAllocator
@@ -24,10 +24,10 @@ public:
     // from a const function.
     typedef struct tag_Variables {
         cv::Mutex MemTotalChangeMutex;
-        __int64 TotalMem; // total mem allocated by this allocator
-        __int64 CountMemAllocs;
-        __int64 CountMemDeAllocs;
-        __int64 TotalJSMem; // total mem told to JS so far
+        int64_t TotalMem; // total mem allocated by this allocator
+        int64_t CountMemAllocs;
+        int64_t CountMemDeAllocs;
+        int64_t TotalJSMem; // total mem told to JS so far
 
         // the main JS thread
         std::thread::id main_thread_id;
@@ -52,10 +52,10 @@ public:
     bool allocate(cv::UMatData* u, int /*accessFlags*/, cv::UMatUsageFlags /*usageFlags*/) const;
     void deallocate(cv::UMatData* u) const;
 
-    __int64 readtotalmem();
-    __int64 readmeminformed();
-    __int64 readnumallocated();
-    __int64 readnumdeallocated();
+    int64_t readtotalmem();
+    int64_t readmeminformed();
+    int64_t readnumallocated();
+    int64_t readnumdeallocated();
 
     // function which adjusts NAN mem to match allocated mem.
     // WILL ONLY ACTUALLY DO ANYTHING FROM MAIN JS LOOP

--- a/cc/core/CustomAllocator.h
+++ b/cc/core/CustomAllocator.h
@@ -1,6 +1,8 @@
 #ifndef __FF_CUSTOMALLOCATOR_H__
 #define __FF_CUSTOMALLOCATOR_H__
 
+#include <thread>
+
 #include "Converters.h"
 #include "Size.h"
 #include "coreUtils.h"
@@ -28,7 +30,7 @@ public:
         __int64 TotalJSMem; // total mem told to JS so far
 
         // the main JS thread
-        uv_thread_t main_thread;
+        std::thread::id main_thread_id;
     } VARIABLES;
 
     CustomMatAllocator( ) { 
@@ -39,7 +41,7 @@ public:
         variables->CountMemDeAllocs = 0;
         variables->TotalJSMem = 0; // total mem told to JS so far
         
-        variables->main_thread = uv_thread_self(); // get the main thread at create
+        variables->main_thread_id = std::this_thread::get_id();
     }
     ~CustomMatAllocator( ) { 
         delete variables;

--- a/cc/core/CustomAllocator.h
+++ b/cc/core/CustomAllocator.h
@@ -1,0 +1,68 @@
+#ifndef __FF_CUSTOMALLOCATOR_H__
+#define __FF_CUSTOMALLOCATOR_H__
+
+#include "Converters.h"
+#include "Size.h"
+#include "coreUtils.h"
+#include "matUtils.h"
+#include "Vec.h"
+#include "Point2.h"
+#include "Rect.h"
+#include "RotatedRect.h"
+#include "Workers.h"
+#include "CustomAllocator.h"
+
+
+class CustomMatAllocator : public cv::MatAllocator
+{
+public:
+    // strange evilness of the functions being tagged const means that the fns cant change
+    // stuff in the class instance.
+    // so instead create constant pointer to a structure which we are allowed to change, even 
+    // from a const function.
+    typedef struct tag_Variables {
+        cv::Mutex MemTotalChangeMutex;
+        __int64 TotalMem; // total mem allocated by this allocator
+        __int64 CountMemAllocs;
+        __int64 CountMemDeAllocs;
+        __int64 TotalJSMem; // total mem told to JS so far
+
+        // the main JS thread
+        uv_thread_t main_thread;
+    } VARIABLES;
+
+    CustomMatAllocator( ) { 
+        stdAllocator = cv::Mat::getStdAllocator(); 
+        variables = new VARIABLES;
+        variables->TotalMem = 0; // total mem allocated by this allocator
+        variables->CountMemAllocs = 0;
+        variables->CountMemDeAllocs = 0;
+        variables->TotalJSMem = 0; // total mem told to JS so far
+        
+        variables->main_thread = uv_thread_self(); // get the main thread at create
+    }
+    ~CustomMatAllocator( ) { 
+        delete variables;
+    }
+
+    cv::UMatData* allocate(int dims, const int* sizes, int type,
+                       void* data0, size_t* step, int /*flags*/, cv::UMatUsageFlags /*usageFlags*/) const;
+    bool allocate(cv::UMatData* u, int /*accessFlags*/, cv::UMatUsageFlags /*usageFlags*/) const;
+    void deallocate(cv::UMatData* u) const;
+
+    __int64 readtotalmem();
+    __int64 readmeminformed();
+    __int64 readnumallocated();
+    __int64 readnumdeallocated();
+
+    // function which adjusts NAN mem to match allocated mem.
+    // WILL ONLY ACTUALLY DO ANYTHING FROM MAIN JS LOOP
+    void FixupJSMem() const;
+    
+
+    VARIABLES *variables;
+    
+    const cv::MatAllocator* stdAllocator;
+};
+
+#endif

--- a/cc/core/CustomAllocator.h
+++ b/cc/core/CustomAllocator.h
@@ -1,8 +1,6 @@
 #ifndef __FF_CUSTOMALLOCATOR_H__
 #define __FF_CUSTOMALLOCATOR_H__
 
-// only valid for 3.1.0+
-#if CV_VERSION_MINOR > 0
 
 #include <thread>
 #include <stdint.h>
@@ -16,6 +14,9 @@
 #include "Rect.h"
 #include "RotatedRect.h"
 #include "Workers.h"
+
+// only valid for 3.1.0+
+#if CV_VERSION_MINOR > 0
 
 
 class CustomMatAllocator : public cv::MatAllocator

--- a/cc/core/Mat.cc
+++ b/cc/core/Mat.cc
@@ -99,8 +99,6 @@ NAN_MODULE_INIT(Mat::Init) {
 
 	Nan::SetPrototypeMethod(ctor, "release", Release);
 
-	Nan::SetPrototypeMethod(ctor, "getMemMetrics", GetMemMetrics);
-
 	FF_PROTO_SET_MAT_OPERATIONS(ctor);
 
 	MatImgproc::Init(ctor);
@@ -1284,29 +1282,3 @@ NAN_METHOD(Mat::Release) {
     mat->release();
 };
 
-
-
-NAN_METHOD(Mat::GetMemMetrics) {
-  Nan::HandleScope scope;
-    
-  __int64 TotalAlloc = -1;
-  __int64 TotalKnownByJS = -1;
-  __int64 NumAllocations = -1;
-  __int64 NumDeAllocations = -1;
-
-  if (Mat::custommatallocator != NULL){
-    TotalAlloc = Mat::custommatallocator->readtotalmem();
-    TotalKnownByJS = Mat::custommatallocator->readmeminformed();
-    NumAllocations = Mat::custommatallocator->readnumallocated();
-    NumDeAllocations = Mat::custommatallocator->readnumdeallocated();
-  }
-
-  FF_OBJ result = FF_NEW_OBJ(); 
-  Nan::Set(result, FF_NEW_STRING("TotalAlloc"), Nan::New((int)TotalAlloc));
-  Nan::Set(result, FF_NEW_STRING("TotalKnownByJS"), Nan::New((int)TotalKnownByJS));
-  Nan::Set(result, FF_NEW_STRING("NumAllocations"), Nan::New((int)NumAllocations));
-  Nan::Set(result, FF_NEW_STRING("NumDeAllocations"), Nan::New((int)NumDeAllocations));
-
-  info.GetReturnValue().Set(result);
-  return;
-}

--- a/cc/core/Mat.cc
+++ b/cc/core/Mat.cc
@@ -1,20 +1,25 @@
 #include "Mat.h"
 #include "MatImgproc.h"
 #include "MatCalib3d.h"
-#include "CustomAllocator.h"
 
 
 Nan::Persistent<v8::FunctionTemplate> Mat::constructor;
 
+// only valid for 3.1.0+
+#if CV_VERSION_MINOR > 0
 CustomMatAllocator *Mat::custommatallocator = NULL;
+#endif  
   
 
 NAN_MODULE_INIT(Mat::Init) {
     
+// only valid for 3.1.0+
+#if CV_VERSION_MINOR > 0
   if (NULL == custommatallocator){
     custommatallocator = new CustomMatAllocator();
     cv::Mat::setDefaultAllocator(custommatallocator);
   }
+#endif  
 
   v8::Local<v8::FunctionTemplate> ctor = Nan::New<v8::FunctionTemplate>(Mat::New);
   constructor.Reset(ctor);
@@ -182,11 +187,15 @@ NAN_METHOD(Mat::New) {
 	}
 	self->Wrap(info.Holder());
     
+// only valid for 3.1.0+
+#if CV_VERSION_MINOR > 0
     // I *think* New should be called in JS thread where cv::mat has been created async,
     // so a good place to rationalise memory
     if (self->custommatallocator){
         self->custommatallocator->FixupJSMem();
     }
+#endif
+    
 	FF_RETURN(info.Holder());
 }
 

--- a/cc/core/Mat.cc
+++ b/cc/core/Mat.cc
@@ -5,20 +5,24 @@
 
 Nan::Persistent<v8::FunctionTemplate> Mat::constructor;
 
-// only valid for 3.1.0+
-#if CV_VERSION_MINOR > 0
+#ifdef OPENCV4NODEJS_ENABLE_EXTERNALMEMTRACKING
 CustomMatAllocator *Mat::custommatallocator = NULL;
 #endif  
-  
+
 
 NAN_MODULE_INIT(Mat::Init) {
     
-// only valid for 3.1.0+
-#if CV_VERSION_MINOR > 0
+// defined in CustomAllocator.h, depends on ocv >= 3.1.0
+#ifdef OPENCV4NODEJS_ENABLE_EXTERNALMEMTRACKING
+
+// defined in CustomAllocator.h
+#ifdef OPENCV4NODEJS_ENABLE_EXTERNALMEMTRACKING_DEFAULT_ON
   if (NULL == custommatallocator){
     custommatallocator = new CustomMatAllocator();
     cv::Mat::setDefaultAllocator(custommatallocator);
   }
+#endif
+  
 #endif  
 
   v8::Local<v8::FunctionTemplate> ctor = Nan::New<v8::FunctionTemplate>(Mat::New);
@@ -187,8 +191,7 @@ NAN_METHOD(Mat::New) {
 	}
 	self->Wrap(info.Holder());
     
-// only valid for 3.1.0+
-#if CV_VERSION_MINOR > 0
+#ifdef OPENCV4NODEJS_ENABLE_EXTERNALMEMTRACKING
     // I *think* New should be called in JS thread where cv::mat has been created async,
     // so a good place to rationalise memory
     if (self->custommatallocator){
@@ -1283,11 +1286,10 @@ void Mat::setNativeProps(cv::Mat mat) {
 	this->mat = mat;
 };
 
-
 // free memory for this mat
 NAN_METHOD(Mat::Release) {
     // must get pointer to the original; else we are just getting a COPY and then releasing that!
     cv::Mat *mat = &(Nan::ObjectWrap::Unwrap<Mat>(info.This())->mat);
     mat->release();
-};
+}
 

--- a/cc/core/Mat.cc
+++ b/cc/core/Mat.cc
@@ -1,10 +1,21 @@
 #include "Mat.h"
 #include "MatImgproc.h"
 #include "MatCalib3d.h"
+#include "CustomAllocator.h"
+
 
 Nan::Persistent<v8::FunctionTemplate> Mat::constructor;
 
+CustomMatAllocator *Mat::custommatallocator = NULL;
+  
+
 NAN_MODULE_INIT(Mat::Init) {
+    
+  if (NULL == custommatallocator){
+    custommatallocator = new CustomMatAllocator();
+    cv::Mat::setDefaultAllocator(custommatallocator);
+  }
+
   v8::Local<v8::FunctionTemplate> ctor = Nan::New<v8::FunctionTemplate>(Mat::New);
   constructor.Reset(ctor);
   ctor->InstanceTemplate()->SetInternalFieldCount(1);
@@ -85,6 +96,9 @@ NAN_MODULE_INIT(Mat::Init) {
 	Nan::SetPrototypeMethod(ctor, "rotate", Rotate);
 	Nan::SetPrototypeMethod(ctor, "rotateAsync", RotateAsync);
 #endif
+
+	Nan::SetPrototypeMethod(ctor, "getMemMetrics", GetMemMetrics);
+
 	FF_PROTO_SET_MAT_OPERATIONS(ctor);
 
 	MatImgproc::Init(ctor);
@@ -167,6 +181,12 @@ NAN_METHOD(Mat::New) {
 		self->setNativeProps(mat);
 	}
 	self->Wrap(info.Holder());
+    
+    // I *think* New should be called in JS thread where cv::mat has been created async,
+    // so a good place to rationalise memory
+    if (self->custommatallocator){
+        self->custommatallocator->FixupJSMem();
+    }
 	FF_RETURN(info.Holder());
 }
 
@@ -1254,3 +1274,29 @@ void Mat::setNativeProps(cv::Mat mat) {
 	this->mat = mat;
 };
 
+
+
+NAN_METHOD(Mat::GetMemMetrics) {
+  Nan::HandleScope scope;
+    
+  __int64 TotalAlloc = -1;
+  __int64 TotalKnownByJS = -1;
+  __int64 NumAllocations = -1;
+  __int64 NumDeAllocations = -1;
+
+  if (Mat::custommatallocator != NULL){
+    TotalAlloc = Mat::custommatallocator->readtotalmem();
+    TotalKnownByJS = Mat::custommatallocator->readmeminformed();
+    NumAllocations = Mat::custommatallocator->readnumallocated();
+    NumDeAllocations = Mat::custommatallocator->readnumdeallocated();
+  }
+
+  FF_OBJ result = FF_NEW_OBJ(); 
+  Nan::Set(result, FF_NEW_STRING("TotalAlloc"), Nan::New((int)TotalAlloc));
+  Nan::Set(result, FF_NEW_STRING("TotalKnownByJS"), Nan::New((int)TotalKnownByJS));
+  Nan::Set(result, FF_NEW_STRING("NumAllocations"), Nan::New((int)NumAllocations));
+  Nan::Set(result, FF_NEW_STRING("NumDeAllocations"), Nan::New((int)NumDeAllocations));
+
+  info.GetReturnValue().Set(result);
+  return;
+}

--- a/cc/core/Mat.h
+++ b/cc/core/Mat.h
@@ -7,6 +7,8 @@
 #include "Rect.h"
 #include "RotatedRect.h"
 #include "Workers.h"
+#include "CustomAllocator.h"
+
 
 #ifndef __FF_MAT_H__
 #define __FF_MAT_H__
@@ -14,6 +16,8 @@
 class Mat : public Nan::ObjectWrap {
 public:
   cv::Mat mat;
+  
+  static CustomMatAllocator *custommatallocator;
 
   static NAN_MODULE_INIT(Init);
 	static NAN_METHOD(New);
@@ -148,6 +152,9 @@ public:
 	static NAN_METHOD(Rotate);
 	static NAN_METHOD(RotateAsync);
 #endif
+
+    static NAN_METHOD(GetMemMetrics);
+
 
   static Nan::Persistent<v8::FunctionTemplate> constructor;
 

--- a/cc/core/Mat.h
+++ b/cc/core/Mat.h
@@ -155,9 +155,6 @@ public:
 
 	static NAN_METHOD(Release);
 
-    static NAN_METHOD(GetMemMetrics);
-
-
   static Nan::Persistent<v8::FunctionTemplate> constructor;
 
 	void setNativeProps(cv::Mat);

--- a/cc/core/Mat.h
+++ b/cc/core/Mat.h
@@ -8,10 +8,7 @@
 #include "RotatedRect.h"
 #include "Workers.h"
 
-// only valid for 3.1.0+
-#if CV_VERSION_MINOR > 0
 #include "CustomAllocator.h"
-#endif
 
 #ifndef __FF_MAT_H__
 #define __FF_MAT_H__
@@ -20,8 +17,7 @@ class Mat : public Nan::ObjectWrap {
 public:
   cv::Mat mat;
   
-// only valid for 3.1.0+
-#if CV_VERSION_MINOR > 0
+#ifdef OPENCV4NODEJS_ENABLE_EXTERNALMEMTRACKING
   static CustomMatAllocator *custommatallocator;
 #endif
 

--- a/cc/core/Mat.h
+++ b/cc/core/Mat.h
@@ -7,8 +7,11 @@
 #include "Rect.h"
 #include "RotatedRect.h"
 #include "Workers.h"
-#include "CustomAllocator.h"
 
+// only valid for 3.1.0+
+#if CV_VERSION_MINOR > 0
+#include "CustomAllocator.h"
+#endif
 
 #ifndef __FF_MAT_H__
 #define __FF_MAT_H__
@@ -17,7 +20,10 @@ class Mat : public Nan::ObjectWrap {
 public:
   cv::Mat mat;
   
+// only valid for 3.1.0+
+#if CV_VERSION_MINOR > 0
   static CustomMatAllocator *custommatallocator;
+#endif
 
   static NAN_MODULE_INIT(Init);
 	static NAN_METHOD(New);

--- a/cc/core/core.cc
+++ b/cc/core/core.cc
@@ -226,12 +226,15 @@ NAN_METHOD(Core::GetMemMetrics) {
   int64_t NumAllocations = -1;
   int64_t NumDeAllocations = -1;
 
+// only valid for 3.1.0+
+#if CV_VERSION_MINOR > 0
   if (Mat::custommatallocator != NULL){
     TotalAlloc = Mat::custommatallocator->readtotalmem();
     TotalKnownByJS = Mat::custommatallocator->readmeminformed();
     NumAllocations = Mat::custommatallocator->readnumallocated();
     NumDeAllocations = Mat::custommatallocator->readnumdeallocated();
   }
+#endif
 
   FF_OBJ result = FF_NEW_OBJ(); 
   Nan::Set(result, FF_NEW_STRING("TotalAlloc"), Nan::New((double)TotalAlloc));

--- a/cc/core/core.cc
+++ b/cc/core/core.cc
@@ -45,6 +45,8 @@ NAN_MODULE_INIT(Core::Init) {
 	Nan::SetMethod(target, "cartToPolarAsync", CartToPolarAsync);
 	Nan::SetMethod(target, "polarToCart", PolarToCart);
 	Nan::SetMethod(target, "polarToCartAsync", PolarToCartAsync);
+	Nan::SetMethod(target, "getMemMetrics", GetMemMetrics);
+    
 };
 
 NAN_METHOD(Core::Partition) {
@@ -215,3 +217,30 @@ NAN_METHOD(Core::PolarToCartAsync) {
 	PolarToCartWorker worker;
 	FF_WORKER_ASYNC("Mat::PolarToCartAsync", PolarToCartWorker, worker);
 }
+
+
+NAN_METHOD(Core::GetMemMetrics) {
+    
+  int64_t TotalAlloc = -1;
+  int64_t TotalKnownByJS = -1;
+  int64_t NumAllocations = -1;
+  int64_t NumDeAllocations = -1;
+
+  if (Mat::custommatallocator != NULL){
+    TotalAlloc = Mat::custommatallocator->readtotalmem();
+    TotalKnownByJS = Mat::custommatallocator->readmeminformed();
+    NumAllocations = Mat::custommatallocator->readnumallocated();
+    NumDeAllocations = Mat::custommatallocator->readnumdeallocated();
+  }
+
+  FF_OBJ result = FF_NEW_OBJ(); 
+  Nan::Set(result, FF_NEW_STRING("TotalAlloc"), Nan::New((double)TotalAlloc));
+  Nan::Set(result, FF_NEW_STRING("TotalKnownByJS"), Nan::New((double)TotalKnownByJS));
+  Nan::Set(result, FF_NEW_STRING("NumAllocations"), Nan::New((double)NumAllocations));
+  Nan::Set(result, FF_NEW_STRING("NumDeAllocations"), Nan::New((double)NumDeAllocations));
+
+  info.GetReturnValue().Set(result);
+  return;
+}
+
+

--- a/cc/core/core.cc
+++ b/cc/core/core.cc
@@ -250,13 +250,16 @@ NAN_METHOD(Core::GetMemMetrics) {
 
 NAN_METHOD(Core::GetCustomAllocator) {
     int allocatorOn = 0;
+#ifdef OPENCV4NODEJS_ENABLE_EXTERNALMEMTRACKING
     if (Mat::custommatallocator != NULL){
         allocatorOn = 1;
     }
+#endif    
     info.GetReturnValue().Set(allocatorOn);
 }
 
 NAN_METHOD(Core::SetCustomAllocator) {
+#ifdef OPENCV4NODEJS_ENABLE_EXTERNALMEMTRACKING
     int input = 1;
 	if (info.Length() == 1 && info[0]->IsInt32()) {
 		input = info[0]->Int32Value();
@@ -286,6 +289,11 @@ NAN_METHOD(Core::SetCustomAllocator) {
             //delete allocator;
         }
     }
+    info.GetReturnValue().Set(input);
+#else    
+    // indicate can't enable in ocv < 3.1.0
+    info.GetReturnValue().Set(0);
+#endif        
     
 }
 

--- a/cc/core/core.h
+++ b/cc/core/core.h
@@ -19,6 +19,9 @@ public:
 	static NAN_METHOD(PolarToCart);
 	static NAN_METHOD(PolarToCartAsync);
     
+	static NAN_METHOD(GetCustomAllocator);
+	static NAN_METHOD(SetCustomAllocator);
+    
     static NAN_METHOD(GetMemMetrics);
     
 };

--- a/cc/core/core.h
+++ b/cc/core/core.h
@@ -18,6 +18,9 @@ public:
 	struct PolarToCartWorker;
 	static NAN_METHOD(PolarToCart);
 	static NAN_METHOD(PolarToCartAsync);
+    
+    static NAN_METHOD(GetMemMetrics);
+    
 };
 
 #endif


### PR DESCRIPTION
This ensures that JS always knows (close enough) what memory is in use by native Mat objects, and keeps memory under control automagically.

Whenever a mat is allocated, the custom allocator notes the amount of ram allocated.
Whenever a mat is released,  the custom allocator notes the amount of ram freed.

Node can only be told about the memory changes in the main NodeJS thread; so every allocation/deallocation TRIES to inform node, but does not if not on the main thread.  Also, on new Mat, the reconciliation function is called - this catches allocation which have been done inside an Async process, where a Mat is returned (since most fns return the native cv::mat, which is wrapped in a new JSMat in the main thread).