### PR TITLE
Add: VideoCapture.setAsync

### DIFF
--- a/cc/modules/io/VideoCapture.h
+++ b/cc/modules/io/VideoCapture.h
@@ -1,3 +1,4 @@
+#include "Converters.h"
 #include "macros.h"
 #include <opencv2/highgui.hpp>
 #include "Mat.h"
@@ -17,6 +18,7 @@ public:
 	static NAN_METHOD(ReadAsync);
 	static NAN_METHOD(Get);
 	static NAN_METHOD(Set);
+	static NAN_METHOD(SetAsync);
 	static NAN_METHOD(Release);
 
 	static Nan::Persistent<v8::FunctionTemplate> constructor;
@@ -37,6 +39,7 @@ public:
 			return jsMat;
 		}
 	};
+	struct SetWorker;
 };
 
 #endif

--- a/lib/typings/VideoCapture.d.ts
+++ b/lib/typings/VideoCapture.d.ts
@@ -8,5 +8,6 @@ export class VideoCapture {
   readAsync(): Promise<Mat>;
   release(): void;
   reset(): void;
-  set(property: number, value: number): void;
+  set(property: number, value: number): boolean;
+  setAsync(property: number, value: number): Promise<boolean>;
 }

--- a/test/tests/modules/io/videoCaptureTests.js
+++ b/test/tests/modules/io/videoCaptureTests.js
@@ -45,5 +45,24 @@ module.exports = () => {
         expect(cap.get(cv.CAP_PROP_FRAME_HEIGHT)).to.equal(360);
       });
     });
+
+    describe('set', () => {
+      it('should set properties', () => {
+        const cap = new cv.VideoCapture(getTestVideoPath());
+        const wasSet = cap.set(cv.CAP_PROP_POS_MSEC, 1000)
+        expect(cap.get(cv.CAP_PROP_POS_MSEC)|0).to.equal(1001);
+        expect(wasSet).to.equal(true);
+      });
+    });
+    describe('setAsync', () => {
+      it('should set properties', () => {
+        const cap = new cv.VideoCapture(getTestVideoPath());
+        cap.setAsync(cv.CAP_PROP_POS_MSEC, 1000, (err, wasSet) => {
+           expect(cap.get(cv.CAP_PROP_POS_MSEC)|0).to.equal(1001);
+           expect(wasSet).to.equal(true);
+        })
+      });
+    });
+
   });
 };


### PR DESCRIPTION
For example, `VideoCapture.setAsync` can be used when seeking through a video via `cap.setAsync(cv.CAP_PROP_POS_MSEC, second / 1000)`.

When you are doing some processing for a couple sets of frames, the processing takes ~60ms and seeking ~50ms, it would be nice to get the first frame and while processing it, seek to the next one, and have it ready for the next iteration of processing.