### PR TITLE
External mem tracking followup

### DIFF
--- a/appveyor.yml
+++ b/appveyor.yml
@@ -55,3 +55,4 @@ test_script:
   - cmd: cd c:\projects\opencv4nodejs\test
   - npm install
   - npm run test-appveyor
+  - npm run test-externalMemTracking

--- a/binding.gyp
+++ b/binding.gyp
@@ -17,11 +17,12 @@
 		],
 		"sources": [
 			"cc/opencv4nodejs.cc",
+			"cc/CustomMatAllocator.cc",
+			"cc/ExternalMemTracking.cc",
 			"cc/cvTypes/cvTypes.cc",
 			"cc/cvTypes/imgprocConstants.cc",
 			"cc/cvTypes/videoCaptureProps.cc",
 			"cc/core/core.cc",
-			"cc/core/CustomAllocator.cc",
 			"cc/core/Mat.cc",
 			"cc/core/MatImgproc.cc",
 			"cc/core/MatCalib3d.cc",

--- a/cc/CustomMatAllocator.cc
+++ b/cc/CustomMatAllocator.cc
@@ -1,6 +1,4 @@
-
-
-#include "CustomAllocator.h"
+#include "CustomMatAllocator.h"
 //#include <iostream>
 
 #ifdef OPENCV4NODEJS_ENABLE_EXTERNALMEMTRACKING
@@ -9,7 +7,7 @@ cv::UMatData* CustomMatAllocator::allocate(int dims, const int* sizes, int type,
                        void* data0, size_t* step, int flags, cv::UMatUsageFlags usageFlags) const
 {
     cv::UMatData* u = stdAllocator->allocate(dims, sizes, type, data0, step, flags, usageFlags);
-    
+
     if (NULL != u){
         u->prevAllocator = u->currAllocator = this;
         if( !(u->flags & cv::UMatData::USER_ALLOCATED) ){
@@ -21,7 +19,7 @@ cv::UMatData* CustomMatAllocator::allocate(int dims, const int* sizes, int type,
                 variables->MemTotalChangeMutex.unlock();
                 this->FixupJSMem();
             } catch (...){
-                printf("exception adjusting memory\n");
+                printf("CustomMatAllocator::allocate - exception adjusting memory\n");
             }
         }
     }
@@ -95,7 +93,7 @@ void CustomMatAllocator::FixupJSMem() const {
         int64_t adjust = variables->TotalMem - variables->TotalJSMem;
         variables->TotalJSMem += adjust;
         variables->MemTotalChangeMutex.unlock();
-        
+
         if (adjust){
             //printf("will call Nan ajust by %d\n", (int)adjust);
             Nan::AdjustExternalMemory(adjust);

--- a/cc/CustomMatAllocator.h
+++ b/cc/CustomMatAllocator.h
@@ -1,6 +1,5 @@
-#ifndef __FF_CUSTOMALLOCATOR_H__
-#define __FF_CUSTOMALLOCATOR_H__
-
+#ifndef __FF_CUSTOMATMALLOCATOR_H__
+#define __FF_CUSTOMATMALLOCATOR_H__
 
 #include <thread>
 #include <stdint.h>
@@ -23,15 +22,12 @@
 
 #ifdef OPENCV4NODEJS_ENABLE_EXTERNALMEMTRACKING
 
-// un-comment to enable by default
-// #define OPENCV4NODEJS_ENABLE_EXTERNALMEMTRACKING_DEFAULT_ON
-
 class CustomMatAllocator : public cv::MatAllocator
 {
 public:
     // strange evilness of the functions being tagged const means that the fns cant change
     // stuff in the class instance.
-    // so instead create constant pointer to a structure which we are allowed to change, even 
+    // so instead create constant pointer to a structure which we are allowed to change, even
     // from a const function.
     typedef struct tag_Variables {
         cv::Mutex MemTotalChangeMutex;
@@ -44,17 +40,17 @@ public:
         std::thread::id main_thread_id;
     } VARIABLES;
 
-    CustomMatAllocator( ) { 
-        stdAllocator = cv::Mat::getStdAllocator(); 
+    CustomMatAllocator( ) {
+        stdAllocator = cv::Mat::getStdAllocator();
         variables = new VARIABLES;
         variables->TotalMem = 0; // total mem allocated by this allocator
         variables->CountMemAllocs = 0;
         variables->CountMemDeAllocs = 0;
         variables->TotalJSMem = 0; // total mem told to JS so far
-        
+
         variables->main_thread_id = std::this_thread::get_id();
     }
-    ~CustomMatAllocator( ) { 
+    ~CustomMatAllocator( ) {
         delete variables;
         variables = NULL;
     }
@@ -72,10 +68,10 @@ public:
     // function which adjusts NAN mem to match allocated mem.
     // WILL ONLY ACTUALLY DO ANYTHING FROM MAIN JS LOOP
     void FixupJSMem() const;
-    
+
 
     VARIABLES *variables;
-    
+
     const cv::MatAllocator* stdAllocator;
 };
 

--- a/cc/ExternalMemTracking.cc
+++ b/cc/ExternalMemTracking.cc
@@ -1,0 +1,100 @@
+#include "ExternalMemTracking.h"
+#include <iostream>
+
+#ifdef OPENCV4NODEJS_ENABLE_EXTERNALMEMTRACKING
+CustomMatAllocator *ExternalMemTracking::custommatallocator = NULL;
+#endif
+
+NAN_MODULE_INIT(ExternalMemTracking::Init) {
+#ifdef OPENCV4NODEJS_ENABLE_EXTERNALMEMTRACKING
+	try {
+		char* env = std::getenv("OPENCV4NODEJS_DISABLE_EXTERNAL_MEM_TRACKING");
+		if (env == NULL && custommatallocator == NULL) {
+			custommatallocator = new CustomMatAllocator();
+			cv::Mat::setDefaultAllocator(custommatallocator);
+		}
+	}
+	catch (...) {
+		printf("ExternalMemTracking::Init - fatal exception while trying to read env: OPENCV4NODEJS_DISABLE_EXTERNAL_MEM_TRACKING");
+	}
+#endif  
+	Nan::SetMethod(target, "isCustomMatAllocatorEnabled", IsCustomMatAllocatorEnabled);
+	Nan::SetMethod(target, "dangerousEnableCustomMatAllocator", DangerousEnableCustomMatAllocator);
+	Nan::SetMethod(target, "dangerousDisableCustomMatAllocator", DangerousDisableCustomMatAllocator);
+	Nan::SetMethod(target, "getMemMetrics", GetMemMetrics);
+};
+
+NAN_METHOD(ExternalMemTracking::GetMemMetrics) {
+
+  int64_t TotalAlloc = -1;
+  int64_t TotalKnownByJS = -1;
+  int64_t NumAllocations = -1;
+  int64_t NumDeAllocations = -1;
+
+#ifdef OPENCV4NODEJS_ENABLE_EXTERNALMEMTRACKING
+  if (ExternalMemTracking::custommatallocator != NULL){
+    TotalAlloc = ExternalMemTracking::custommatallocator->readtotalmem();
+    TotalKnownByJS = ExternalMemTracking::custommatallocator->readmeminformed();
+    NumAllocations = ExternalMemTracking::custommatallocator->readnumallocated();
+    NumDeAllocations = ExternalMemTracking::custommatallocator->readnumdeallocated();
+  }
+#endif
+
+  FF_OBJ result = FF_NEW_OBJ();
+  Nan::Set(result, FF_NEW_STRING("TotalAlloc"), Nan::New((double)TotalAlloc));
+  Nan::Set(result, FF_NEW_STRING("TotalKnownByJS"), Nan::New((double)TotalKnownByJS));
+  Nan::Set(result, FF_NEW_STRING("NumAllocations"), Nan::New((double)NumAllocations));
+  Nan::Set(result, FF_NEW_STRING("NumDeAllocations"), Nan::New((double)NumDeAllocations));
+
+  info.GetReturnValue().Set(result);
+  return;
+}
+
+
+NAN_METHOD(ExternalMemTracking::IsCustomMatAllocatorEnabled) {
+    bool allocatorOn = false;
+#ifdef OPENCV4NODEJS_ENABLE_EXTERNALMEMTRACKING
+    if (ExternalMemTracking::custommatallocator != NULL){
+		allocatorOn = true;
+    }
+#endif
+    info.GetReturnValue().Set(allocatorOn);
+}
+
+NAN_METHOD(ExternalMemTracking::DangerousEnableCustomMatAllocator) {
+	bool success = false;
+#ifdef OPENCV4NODEJS_ENABLE_EXTERNALMEMTRACKING
+	if (ExternalMemTracking::custommatallocator == NULL) {
+		ExternalMemTracking::custommatallocator = new CustomMatAllocator();
+		cv::Mat::setDefaultAllocator(ExternalMemTracking::custommatallocator);
+	}
+	success = ExternalMemTracking::custommatallocator != NULL;
+#endif
+	info.GetReturnValue().Set(success);
+}
+
+NAN_METHOD(ExternalMemTracking::DangerousDisableCustomMatAllocator) {
+	bool success = false;
+#ifdef OPENCV4NODEJS_ENABLE_EXTERNALMEMTRACKING
+	if (ExternalMemTracking::custommatallocator != NULL) {
+		CustomMatAllocator *allocator = ExternalMemTracking::custommatallocator;
+
+		// return default allocator
+		if (allocator->variables) {
+			allocator->variables->MemTotalChangeMutex.lock();
+		}
+		cv::Mat::setDefaultAllocator(NULL);
+		ExternalMemTracking::custommatallocator = NULL;
+		if (allocator->variables) {
+			allocator->variables->MemTotalChangeMutex.unlock();
+		}
+
+		// sorry, can't delete it, since it may be references by a number of outstanding Mats -> memory leak, but it's small
+		// and should not happen often, or ever!.
+		//delete allocator;
+	}
+	success = ExternalMemTracking::custommatallocator == NULL;
+#endif
+	info.GetReturnValue().Set(success);
+}
+

--- a/cc/ExternalMemTracking.h
+++ b/cc/ExternalMemTracking.h
@@ -1,0 +1,30 @@
+#include "macros.h"
+#include "CustomMatAllocator.h"
+
+#ifndef __FF_EXTERNALMEMTRACKING_H__
+#define __FF_EXTERNALMEMTRACKING_H__
+
+class ExternalMemTracking {
+public:
+
+#ifdef OPENCV4NODEJS_ENABLE_EXTERNALMEMTRACKING
+	static CustomMatAllocator *custommatallocator;
+#endif
+
+	static inline void onMatAllocated() {
+#ifdef OPENCV4NODEJS_ENABLE_EXTERNALMEMTRACKING
+		if (custommatallocator != NULL) {
+			custommatallocator->FixupJSMem();
+		}
+#endif
+	}
+
+	static NAN_MODULE_INIT(Init);
+	static NAN_METHOD(IsCustomMatAllocatorEnabled);
+	static NAN_METHOD(GetMemMetrics);
+	static NAN_METHOD(DangerousEnableCustomMatAllocator);
+	static NAN_METHOD(DangerousDisableCustomMatAllocator);
+
+};
+
+#endif

--- a/cc/core/Mat.cc
+++ b/cc/core/Mat.cc
@@ -175,7 +175,7 @@ NAN_METHOD(Mat::New) {
 	}
 	self->Wrap(info.Holder());
     
-	// if ExternalMemTracking, the following instruction will be a no op
+	// if ExternalMemTracking is disabled, the following instruction will be a no op
     // notes: I *think* New should be called in JS thread where cv::mat has been created async,
     // so a good place to rationalise memory
 	ExternalMemTracking::onMatAllocated();

--- a/cc/core/Mat.h
+++ b/cc/core/Mat.h
@@ -8,20 +8,14 @@
 #include "RotatedRect.h"
 #include "Workers.h"
 
-#include "CustomAllocator.h"
-
 #ifndef __FF_MAT_H__
 #define __FF_MAT_H__
 
 class Mat : public Nan::ObjectWrap {
 public:
-  cv::Mat mat;
+	cv::Mat mat;
   
-#ifdef OPENCV4NODEJS_ENABLE_EXTERNALMEMTRACKING
-  static CustomMatAllocator *custommatallocator;
-#endif
-
-  static NAN_MODULE_INIT(Init);
+	static NAN_MODULE_INIT(Init);
 	static NAN_METHOD(New);
 
 	static NAN_METHOD(Eye);

--- a/cc/core/core.cc
+++ b/cc/core/core.cc
@@ -45,10 +45,6 @@ NAN_MODULE_INIT(Core::Init) {
 	Nan::SetMethod(target, "cartToPolarAsync", CartToPolarAsync);
 	Nan::SetMethod(target, "polarToCart", PolarToCart);
 	Nan::SetMethod(target, "polarToCartAsync", PolarToCartAsync);
-	Nan::SetMethod(target, "getCustomAllocator", GetCustomAllocator);
-	Nan::SetMethod(target, "setCustomAllocator", SetCustomAllocator);
-	Nan::SetMethod(target, "getMemMetrics", GetMemMetrics);
-    
 };
 
 NAN_METHOD(Core::Partition) {
@@ -219,81 +215,3 @@ NAN_METHOD(Core::PolarToCartAsync) {
 	PolarToCartWorker worker;
 	FF_WORKER_ASYNC("Mat::PolarToCartAsync", PolarToCartWorker, worker);
 }
-
-
-NAN_METHOD(Core::GetMemMetrics) {
-    
-  int64_t TotalAlloc = -1;
-  int64_t TotalKnownByJS = -1;
-  int64_t NumAllocations = -1;
-  int64_t NumDeAllocations = -1;
-
-#ifdef OPENCV4NODEJS_ENABLE_EXTERNALMEMTRACKING
-  if (Mat::custommatallocator != NULL){
-    TotalAlloc = Mat::custommatallocator->readtotalmem();
-    TotalKnownByJS = Mat::custommatallocator->readmeminformed();
-    NumAllocations = Mat::custommatallocator->readnumallocated();
-    NumDeAllocations = Mat::custommatallocator->readnumdeallocated();
-  }
-#endif
-
-  FF_OBJ result = FF_NEW_OBJ(); 
-  Nan::Set(result, FF_NEW_STRING("TotalAlloc"), Nan::New((double)TotalAlloc));
-  Nan::Set(result, FF_NEW_STRING("TotalKnownByJS"), Nan::New((double)TotalKnownByJS));
-  Nan::Set(result, FF_NEW_STRING("NumAllocations"), Nan::New((double)NumAllocations));
-  Nan::Set(result, FF_NEW_STRING("NumDeAllocations"), Nan::New((double)NumDeAllocations));
-
-  info.GetReturnValue().Set(result);
-  return;
-}
-
-
-NAN_METHOD(Core::GetCustomAllocator) {
-    int allocatorOn = 0;
-#ifdef OPENCV4NODEJS_ENABLE_EXTERNALMEMTRACKING
-    if (Mat::custommatallocator != NULL){
-        allocatorOn = 1;
-    }
-#endif    
-    info.GetReturnValue().Set(allocatorOn);
-}
-
-NAN_METHOD(Core::SetCustomAllocator) {
-#ifdef OPENCV4NODEJS_ENABLE_EXTERNALMEMTRACKING
-    int input = 1;
-	if (info.Length() == 1 && info[0]->IsInt32()) {
-		input = info[0]->Int32Value();
-    }
-
-    if (input){
-        if (Mat::custommatallocator == NULL){
-            Mat::custommatallocator = new CustomMatAllocator();
-            cv::Mat::setDefaultAllocator(Mat::custommatallocator);
-        }
-    } else {
-        if (Mat::custommatallocator != NULL){
-            CustomMatAllocator *allocator = Mat::custommatallocator;
-
-            // return default allocator
-            if (allocator->variables){
-                allocator->variables->MemTotalChangeMutex.lock();
-            }
-            cv::Mat::setDefaultAllocator(NULL);
-            Mat::custommatallocator = NULL;
-            if (allocator->variables){
-                allocator->variables->MemTotalChangeMutex.unlock();
-            }
-
-            // sorry, can't delete it, since it may be references by a number of outstanding Mats -> memory leak, but it's small
-            // and should not happen often, or ever!.
-            //delete allocator;
-        }
-    }
-    info.GetReturnValue().Set(input);
-#else    
-    // indicate can't enable in ocv < 3.1.0
-    info.GetReturnValue().Set(0);
-#endif        
-    
-}
-

--- a/cc/core/core.h
+++ b/cc/core/core.h
@@ -18,12 +18,7 @@ public:
 	struct PolarToCartWorker;
 	static NAN_METHOD(PolarToCart);
 	static NAN_METHOD(PolarToCartAsync);
-    
-	static NAN_METHOD(GetCustomAllocator);
-	static NAN_METHOD(SetCustomAllocator);
-    
-    static NAN_METHOD(GetMemMetrics);
-    
+
 };
 
 #endif

--- a/cc/opencv4nodejs.cc
+++ b/cc/opencv4nodejs.cc
@@ -1,6 +1,8 @@
 #include <node.h>
-#include "cvTypes/cvTypes.h"
+#include "ExternalMemTracking.h"
+#include <iostream>
 
+#include "cvTypes/cvTypes.h"
 #include "core.h"
 #include "modules/io/io.h"
 #include "modules/video/video.h"
@@ -31,6 +33,10 @@
 #endif
 
 void init(v8::Local<v8::Object> target) {
+	// can be disabled by defining env variable: OPENCV4NODEJS_DISABLE_EXTERNAL_MEM_TRACKING
+	ExternalMemTracking::Init(target);
+
+
 	v8::Local<v8::Object> version = Nan::New<v8::Object>();
 	Nan::Set(version, FF_NEW_STRING("major"), Nan::New(CV_MAJOR_VERSION));
 	Nan::Set(version, FF_NEW_STRING("minor"), Nan::New(CV_MINOR_VERSION));

--- a/ci/test/script/run-test.sh
+++ b/ci/test/script/run-test.sh
@@ -6,3 +6,4 @@ echo running tests
 cd ./test
 npm install --unsafe-perm
 npm run test-docker
+npm run test-externalMemTracking

--- a/lib/opencv4nodejs.js
+++ b/lib/opencv4nodejs.js
@@ -11,9 +11,9 @@ if (!opencvBuild.isAutoBuildDisabled() && process.platform === 'win32') {
 
 let cv;
 if (process.env.BINDINGS_DEBUG) {
-  cv = require('../build/Debug/opencv4nodejs');
+  cv = require(path.join(__dirname, '../build/Debug/opencv4nodejs'));
 } else {
-  cv = require('../build/Release/opencv4nodejs');
+  cv = require(path.join(__dirname, '../build/Release/opencv4nodejs'));
 }
 
 const { resolvePath } = require('./commons');

--- a/test/dut.js
+++ b/test/dut.js
@@ -3,4 +3,4 @@
 // manipulate binary path for testing
 //process.env.path = process.env.path.replace(process.env.OPENCV_BIN_DIR, process.env.OPENCV30_BIN_DIR);
 
-module.exports = require(process.env.DUT_INSTALLED ? 'opencv4nodejs' : '../');
+module.exports = () => require(process.env.DUT_INSTALLED ? 'opencv4nodejs' : '../');

--- a/test/externalMemTracking/other/index.test.js
+++ b/test/externalMemTracking/other/index.test.js
@@ -1,0 +1,8 @@
+const { expect } = require('chai');
+const requireCv = require('../../dut');
+
+describe('External Memory Tracking', () => {
+  it.skip('no tests specified', () => {
+    // TODO ?
+  });
+});

--- a/test/externalMemTracking/testDefaultDisabled.js
+++ b/test/externalMemTracking/testDefaultDisabled.js
@@ -1,0 +1,13 @@
+const { expect } = require('chai');
+const requireCv = require('../dut');
+
+describe('External Memory Tracking', () => {
+  it('should be enabled (opencv 3.1.0+)/ disabled(opencv 3.0.0) by default', () => {
+    const cv = requireCv();
+    if (cv.version.minor < 1) {
+      expect(cv.isCustomMatAllocatorEnabled()).to.be.false;
+    } else {
+      expect(cv.isCustomMatAllocatorEnabled()).to.be.true;
+    }
+  });
+});

--- a/test/externalMemTracking/testDisableWithEnv.js
+++ b/test/externalMemTracking/testDisableWithEnv.js
@@ -1,0 +1,10 @@
+const { expect } = require('chai');
+const requireCv = require('../dut');
+
+describe('External Memory Tracking', () => {
+  it('should be disabled if OPENCV4NODEJS_DISABLE_EXTERNAL_MEM_TRACKING is set', () => {
+    process.env.OPENCV4NODEJS_DISABLE_EXTERNAL_MEM_TRACKING = 1;
+    const cv = requireCv();
+    expect(cv.isCustomMatAllocatorEnabled()).to.be.false;
+  });
+});

--- a/test/globals.js
+++ b/test/globals.js
@@ -1,4 +1,9 @@
-global.dut = require('./dut');
+// require('segfault-handler').registerHandler('crash.log');
+
+const requireCv = require('./dut');
+
+// requiring cv has to happen before requiring utils
+global.dut = requireCv();
+
 global.utils = require('./utils');
 
-// require('segfault-handler').registerHandler('crash.log');

--- a/test/package.json
+++ b/test/package.json
@@ -5,6 +5,8 @@
     "test": "mocha --require ./globals --timeout 2000 --recursive ./tests",
     "test-appveyor": "mocha --require ./globals --timeout 30000 --recursive ./tests",
     "test-docker": "DOCKER_BUILD=true mocha --require ./globals --timeout 30000 --recursive ./tests",
+    "test-externalMemTrackingOther": "mocha --require ./globals --timeout 30000 --recursive ./externalMemTracking/other",
+    "test-externalMemTracking": "mocha ./externalMemTracking/testDefaultDisabled.js && mocha ./externalMemTracking/testDisableWithEnv.js && npm run test-externalMemTrackingOther",
     "gc": "set WITH_GC=true &&mocha --expose-gc --require ./globals --timeout 2000 --recursive ./tests",
     "cover": "BINDINGS_DEBUG=true istanbul cover node_modules/mocha/bin/_mocha --report lcovonly --require ./globals -- --timeout 30000 --recursive ./tests"
   },


### PR DESCRIPTION
Follow up of #208. 

Mainly did two changes:

1. Move initialization of CustomMatAllactor and methods for retrieving mem metrics and enabling/disabling external mem tracking at runtime to ExternalMemTracking, to have everything in one place and keep logic seperate from Mat and Core, which are mainly for implementing bindings to the OpenCV API + all preprocessor directive checking in a single file mainly.

2. External memory tracking is now enabled by default and the preferred way of disabling it, is via environment flag `OPENCV4NODEJS_DISABLE_EXTERNAL_MEMTRACKING`, which still allows to disable the feature without recompiling, but once at the time of requiring the package instead of arbitrarily at runtime.

For now it is still possible to arbitrarily enable/disable the feature via `dangerousEnableCustomMatAllocator` and `dangerousDisableCustomMatAllocator`, but is generally not recommended.

Maybe you can have a quick look at it @btsimonh whenever you find the time and tell me your opinion about this.