### PR TITLE
Fixed imdecode, imencode and Mat Buffer typings

### DIFF
--- a/lib/typings/Mat.d.ts
+++ b/lib/typings/Mat.d.ts
@@ -32,7 +32,7 @@ export class Mat {
   constructor(dataArray: number[][][], type: number);
   constructor(dataArray: number[][][], type: number);
   constructor(dataArray: number[][][], type: number);
-  constructor(data: number[], rows: number, cols: number, type?: number);
+  constructor(data: Buffer, rows: number, cols: number, type?: number);
   abs(): Mat;
   absdiff(otherMat: Mat): Mat;
   adaptiveThreshold(maxVal: number, adaptiveMethod: number, thresholdType: number, blockSize: number, C: number): Mat;
@@ -156,8 +156,8 @@ export class Mat {
   floodFillAsync(seedPoint: Point2, newVal: Vec3, mask?: Mat, loDiff?: Vec3, upDiff?: Vec3, flags?: number): Promise<{ returnValue: number, rect: Rect }>;
   gaussianBlur(kSize: Size, sigmaX: number, sigmaY?: number, borderType?: number): Mat;
   gaussianBlurAsync(kSize: Size, sigmaX: number, sigmaY?: number, borderType?: number): Promise<Mat>;
-  getData(): number[];
-  getDataAsync(): Promise<number[]>;
+  getData(): Buffer;
+  getDataAsync(): Promise<Buffer>;
   getDataAsArray(): number[][];
   getDataAsArray(): number[][][];
   getDataAsArray(): number[][][];

--- a/lib/typings/cv.d.ts
+++ b/lib/typings/cv.d.ts
@@ -62,10 +62,10 @@ export function getRotationMatrix2D(center: Point2, angle: number, scale?: numbe
 export function getStructuringElement(shape: number, kernelSize: Size, anchor?: Point2): Mat;
 export function getValidDisparityROI(roi1: Rect[], roi2: Rect[], minDisparity: number, numberOfDisparities: number, SADWindowSize: number): Rect;
 export function getValidDisparityROIAsync(roi1: Rect[], roi2: Rect[], minDisparity: number, numberOfDisparities: number, SADWindowSize: number): Promise<Rect>;
-export function imdecode(buffer: number[], flags?: number): Mat;
-export function imdecodeAsync(buffer: number[], flags?: number): Promise<Mat>;
-export function imencode(fileExt: string, img: Mat, flags?: number[]): number[];
-export function imencodeAsync(fileExt: string, img: Mat, flags?: number[]): Promise<number[]>;
+export function imdecode(buffer: Buffer, flags?: number): Mat;
+export function imdecodeAsync(buffer: Buffer, flags?: number): Promise<Mat>;
+export function imencode(fileExt: string, img: Mat, flags?: number[]): Buffer;
+export function imencodeAsync(fileExt: string, img: Mat, flags?: number[]): Promise<Buffer>;
 export function imread(filePath: string, flags?: number): Mat;
 export function imreadAsync(filePath: string, flags?: number): Promise<Mat>;
 export function imshow(winName: string, img: Mat): void;

--- a/package-lock.json
+++ b/package-lock.json
@@ -4,6 +4,12 @@
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {
+    "@types/node": {
+      "version": "9.6.1",
+      "resolved": "https://registry.npmjs.org/@types/node/-/node-9.6.1.tgz",
+      "integrity": "sha512-xwlHq5DXQFRpe+u6hmmNkzYk/3oxxqDp71a/AJMupOQYmxyaBetqrVMqdNlSQfbg7XTJYD8vARjf3Op06OzdtQ==",
+      "optional": true
+    },
     "ansi-regex": {
       "version": "2.1.1",
       "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-2.1.1.tgz",

--- a/package.json
+++ b/package.json
@@ -42,5 +42,8 @@
     "nan": "^2.7.0",
     "native-node-utils": "0.0.4",
     "opencv-build": "0.0.11"
+  },
+  "optionalDependencies": {
+    "@types/node": ">6"
   }
 }


### PR DESCRIPTION
This is the pull request to following issue: https://github.com/justadudewhohacks/opencv4nodejs/issues/233

Fixes the typings for `imdecode`, `imdecodeAsync`, `imencode`, `imencodeAsync`, `Mat constructor` with buffer, `Mat.getData` and `Mat.getDataAsync` with the Node.js Buffer interface.

I checked your general project for `node::buffer` and `Nan::NewBuffer` and found them only in this places, so I hope it should be all places regarding Buffers.