### PR TITLE
Add more helpful C++ error messages

### DIFF
--- a/cc/CatchCvExceptionWorker.h
+++ b/cc/CatchCvExceptionWorker.h
@@ -8,7 +8,7 @@ public:
 	std::string execute() {
 		try {
 			return executeCatchCvExceptionWorker();
-		} catch (std::exception e) {
+		} catch (std::exception &e) {
 			return std::string(e.what());
 		}
 	}


### PR DESCRIPTION
Really minor change but I was running into some errors being thrown in the C++ code due to poorly formatted data from my Javascript code. The error messages being passed back in this case only contained information like `std::exception` so it was difficult to see what the C++ was mad about under the hood.

I've changed the argument passed to the catch block to a reference instead of value because calling `std::exception.what()` on a reference gives you the error message instead of just the `std::exception` type. This does make the error messages a little more verbose but it will pass back the full message thrown from the C++ to the user on the JS side. 