### PR TITLE
Fixed issue #369

### DIFF
--- a/cc/modules/tracking/Tracker.cc
+++ b/cc/modules/tracking/Tracker.cc
@@ -29,8 +29,13 @@ NAN_METHOD(Tracker::Update) {
 	FF_ARG_INSTANCE(0, cv::Mat image, Mat::constructor, FF_UNWRAP_MAT_AND_GET);
 
 	FF_OBJ jsRect = FF_NEW_INSTANCE(Rect::constructor);
-	FF_UNWRAP(info.This(), Tracker)->getTracker()->update(image, FF_UNWRAP_RECT_AND_GET(jsRect));
-	FF_RETURN(jsRect);
+	bool ret = FF_UNWRAP(info.This(), Tracker)->getTracker()->update(image, FF_UNWRAP_RECT_AND_GET(jsRect));
+	
+	if (ret) {
+		FF_RETURN(jsRect);
+	} else {
+		FF_RETURN(Nan::Null());
+	}
 }
 
 NAN_METHOD(Tracker::GetModel) {


### PR DESCRIPTION
Tracker.update() now returns NULL if object is not found rather than always returning a Rect