### PR TITLE
Set MACOSX_DEPLOYMENT_TARGET to 10.9 for Mojave

### DIFF
--- a/binding.gyp
+++ b/binding.gyp
@@ -128,7 +128,8 @@
 				"-std=c++11",
 				"-stdlib=libc++"
 			],
-			"GCC_ENABLE_CPP_EXCEPTIONS": "YES"
+			"GCC_ENABLE_CPP_EXCEPTIONS": "YES",
+			"MACOSX_DEPLOYMENT_TARGET": "10.9"
 		},
 
 		"conditions": [


### PR DESCRIPTION
avoid error "ld: library not found for -lstdc++"
see https://github.com/opencv/opencv/pull/8588

>   SOLINK_MODULE(target) Release/opencv4nodejs.node
> clang: warning: libstdc++ is deprecated; move to libc++ with a minimum deployment target of OS X > 10.9 [-Wdeprecated]
> ld: library not found for -lstdc++
> clang: error: linker command failed with exit code 1 (use -v to see invocation)
> make: *** [Release/opencv4nodejs.node] Error 1