### PR TITLE
Add Point3 possibilty to kmeans

### DIFF
--- a/cc/core/Point.h
+++ b/cc/core/Point.h
@@ -46,15 +46,27 @@ public:
 		}
 		return jsPts;
 	}
-
-	static void unpackJSPoint3Array(std::vector<cv::Point3d> &pts, v8::Local<v8::Array> jsPts) {
+	
+	template<typename type>
+	static v8::Local<v8::Array> packJSPoint3Array(std::vector<cv::Point3_<type>> pts) {
+		v8::Local<v8::Array> jsPts = Nan::New<v8::Array>(pts.size());
+		for (uint i = 0; i < jsPts->Length(); i++) {
+			v8::Local<v8::Object> jsPt3 = FF_NEW_INSTANCE(Point3::constructor);
+			FF_UNWRAP_PT3_AND_GET(jsPt3) = pts.at(i);
+			jsPts->Set(i, jsPt3);
+		}
+		return jsPts;
+	}
+	
+	template<typename type>
+	static void unpackJSPoint3Array(std::vector<cv::Point3_<type>> &pts, v8::Local<v8::Array> jsPts) {
 		for (uint i = 0; i < jsPts->Length(); i++) {
 			v8::Local<v8::Object> obj = Nan::To<v8::Object>(jsPts->Get(i)).ToLocalChecked();
 			double x, y, z;
 			FF_DESTRUCTURE_JSPROP_REQUIRED(obj, x, NumberValue)
 			FF_DESTRUCTURE_JSPROP_REQUIRED(obj, y, NumberValue)
 			FF_DESTRUCTURE_JSPROP_REQUIRED(obj, z, NumberValue)
-			pts.push_back(cv::Point3d(x, y, z));
+			pts.push_back(cv::Point3_<type>(x, y, z));
 		}
 	};
 };

--- a/cc/core/core.cc
+++ b/cc/core/core.cc
@@ -123,32 +123,32 @@ NAN_METHOD(Core::Kmeans) {
   std::vector<int> labels;
   cv::Mat centersMat;
   
-  if (FF_IS_INSTANCE(Point2::constructor, data0) || FF_IS_INSTANCE(Vec2::constructor, data0)) {
+  if (FF_IS_INSTANCE(Point2::constructor, data0)) {
     std::vector<cv::Point2f> data;
     Point::unpackJSPoint2Array(data, jsData);
     cv::kmeans(data, k, labels, termCriteria, attempts, flags, centersMat);
   }
-  else if (FF_IS_INSTANCE(Point3::constructor, data0) || FF_IS_INSTANCE(Vec3::constructor, data0)) {
+  else if (FF_IS_INSTANCE(Point3::constructor, data0)) {
     std::vector<cv::Point3f> data;
     Point::unpackJSPoint3Array(data, jsData);
     cv::kmeans(data, k, labels, termCriteria, attempts, flags, centersMat);
   } 
   else {
-    FF_THROW("unknowned input data type");
+    FF_THROW("expected arg0 to be an Array of Points");
   }
   
   FF_OBJ ret = FF_NEW_OBJ();
   FF_PACK_ARRAY(jsLabels, labels);
   Nan::Set(ret, FF_NEW_STRING("labels"), jsLabels);
 
-  if (FF_IS_INSTANCE(Point2::constructor, data0) || FF_IS_INSTANCE(Vec2::constructor, data0)) {
+  if (FF_IS_INSTANCE(Point2::constructor, data0)) {
     std::vector<cv::Point2f> centers;
     for (int i = 0; i < centersMat.rows; i++) {
       centers.push_back(cv::Point2f(centersMat.at<float>(i, 0), centersMat.at<float>(i, 1)));
     }
     Nan::Set(ret, FF_NEW_STRING("centers"), Point::packJSPoint2Array<float>(centers));
   }
-  else if (FF_IS_INSTANCE(Point3::constructor, data0) || FF_IS_INSTANCE(Vec3::constructor, data0)) {
+  else if (FF_IS_INSTANCE(Point3::constructor, data0)) {
     std::vector<cv::Point3f> centers;
     for (int i = 0; i < centersMat.rows; i++) {
       centers.push_back(cv::Point3f(centersMat.at<float>(i, 0), centersMat.at<float>(i, 1), centersMat.at<float>(i, 2)));

--- a/test/tests/core/core.test.js
+++ b/test/tests/core/core.test.js
@@ -123,9 +123,9 @@ describe('core', () => {
     // related to https://github.com/justadudewhohacks/opencv4nodejs/issues/379
     const points3 = [
       [255, 0, 0], [255, 0, 0], [255, 0, 255], [255, 0, 255], [255, 255, 255]
-    ].map(([r, g, b]) => new cv.Vec3(r, g, b));       
+    ].map(([x, y, z]) => new cv.Point(x, y, z));       
     
-    it('should return correct centers with Vec3', () => {
+    it('should return correct centers with Point3', () => {
       const ret = cv.kmeans(points3, k, termCriteria, attempts, flags);
 
       const l0 = ret.labels[0];
@@ -140,6 +140,21 @@ describe('core', () => {
       expect(ret.centers[l2].x).to.equal(255);
       expect(ret.centers[l2].y).to.equal(255);
       expect(ret.centers[l2].y).to.equal(255);
+    });
+    it('should raise error for invalid type', () => {
+      const points3 = [
+        [255, 0, 0], [255, 0, 0], [255, 0, 255], [255, 0, 255], [255, 255, 255]
+      ].map(([x, y, z]) => new cv.Vec(x, y, z));  
+      
+      let err;
+      
+      try {
+        cv.kmeans(points3, k, termCriteria, attempts, flags);
+      } catch(e){
+        err = e;
+      }
+
+      expect(err.message).to.equal("Core::Kmeans - expected arg0 to be an Array of Points");
     });
   });
   

--- a/test/tests/core/core.test.js
+++ b/test/tests/core/core.test.js
@@ -129,8 +129,8 @@ describe('core', () => {
       const ret = cv.kmeans(points3, k, termCriteria, attempts, flags);
 
       const l0 = ret.labels[0];
-      const l1 = ret.labels[1];
-      const l2 = ret.labels[2];
+      const l1 = ret.labels[2];
+      const l2 = ret.labels[4];
       expect(ret.centers[l0].x).to.equal(255);
       expect(ret.centers[l0].y).to.equal(0);
       expect(ret.centers[l0].z).to.equal(0);

--- a/test/tests/core/core.test.js
+++ b/test/tests/core/core.test.js
@@ -81,23 +81,24 @@ describe('core', () => {
 
   describe('kmeans', () => {
     funcShouldRequireArgs(() => cv.kmeans());
-    const points = [
+    const points2 = [
       [0, 0], [1000, 900], [-1000, -900], [-1100, -1000], [1100, 1000], [10, 10]
     ].map(([x, y]) => new cv.Point(x, y));
+    
     const k = 3;
     const termCriteria = new cv.TermCriteria(cv.termCriteria.COUNT, 100, 0.8);
     const attempts = 10;
     const flags = cv.KMEANS_RANDOM_CENTERS;
 
     it('should return labels and centers', () => {
-      const ret = cv.kmeans(points, k, termCriteria, attempts, flags);
+      const ret = cv.kmeans(points2, k, termCriteria, attempts, flags);
 
       expect(ret).to.have.property('labels').to.be.an('array').lengthOf(6);
       expect(ret).to.have.property('centers').to.be.an('array').lengthOf(k);
     });
 
     it('should return correct labels', () => {
-      const ret = cv.kmeans(points, k, termCriteria, attempts, flags);
+      const ret = cv.kmeans(points2, k, termCriteria, attempts, flags);
 
       const l0 = ret.labels[0];
       const l1 = ret.labels[1];
@@ -106,7 +107,7 @@ describe('core', () => {
     });
 
     it('should return correct centers', () => {
-      const ret = cv.kmeans(points, k, termCriteria, attempts, flags);
+      const ret = cv.kmeans(points2, k, termCriteria, attempts, flags);
 
       const l0 = ret.labels[0];
       const l1 = ret.labels[1];
@@ -118,8 +119,30 @@ describe('core', () => {
       expect(ret.centers[l2].x).to.equal(-1050);
       expect(ret.centers[l2].y).to.equal(-950);
     });
-  });
+    
+    // related to https://github.com/justadudewhohacks/opencv4nodejs/issues/379
+    const points3 = [
+      [255, 0, 0], [255, 0, 0], [255, 0, 255], [255, 0, 255], [255, 255, 255]
+    ].map(([r, g, b]) => new cv.Vec3(r, g, b));       
+    
+    it('should return correct centers with Vec3', () => {
+      const ret = cv.kmeans(points3, k, termCriteria, attempts, flags);
 
+      const l0 = ret.labels[0];
+      const l1 = ret.labels[1];
+      const l2 = ret.labels[2];
+      expect(ret.centers[l0].x).to.equal(255);
+      expect(ret.centers[l0].y).to.equal(0);
+      expect(ret.centers[l0].z).to.equal(0);
+      expect(ret.centers[l1].x).to.equal(255);
+      expect(ret.centers[l1].y).to.equal(0);
+      expect(ret.centers[l1].z).to.equal(255);
+      expect(ret.centers[l2].x).to.equal(255);
+      expect(ret.centers[l2].y).to.equal(255);
+      expect(ret.centers[l2].y).to.equal(255);
+    });
+  });
+  
   describe('cartToPolar', () => {
     const x = new cv.Mat([[0, 1, 100]], cv.CV_32F);
     const y = new cv.Mat([[0, 1, 100]], cv.CV_32F);


### PR DESCRIPTION
Hello @justadudewhohacks,

I did a fix for #379 + unit test.

The example of https://github.com/justadudewhohacks/opencv4nodejs/issues/379#issue-350401307 won't work, cause I think kmeans should only accept `Point3` as input and not `Vec3`.

Example

```js
const { labels, centers } = cv.kmeans(
    [
        new cv.Point3(255, 0, 0),
        new cv.Point3(255, 0, 0),
        new cv.Point3(255, 0, 255),
        new cv.Point3(255, 0, 255),
        new cv.Point3(255, 255, 255)
    ],
    2,
    new cv.TermCriteria(cv.termCriteria.EPS | cv.termCriteria.MAX_ITER, 10, 0.1),
    5,
    cv.KMEANS_RANDOM_CENTERS
);
```

Please share your feedbacks

By the way, thank for this lib, i'm just starting to look inside but it looks better organised than node-opencv.