### PR TITLE
Issue 480

### DIFF
--- a/cc/core/MatBindings.h
+++ b/cc/core/MatBindings.h
@@ -129,8 +129,16 @@ namespace MatBindings {
     size_t size;
     char *data;
 
+    cv::Size sizeTotal;
+    cv::Point ofs;
+
     std::string executeCatchCvExceptionWorker() {
       size = mat.rows * mat.cols * mat.elemSize();
+      mat.locateROI(sizeTotal, ofs);
+      
+      if(sizeTotal.width != mat.cols || sizeTotal.height != mat.rows){
+        return "Cannot call GetData when Region of Interest is defined (i.e. after getRegion) use matrix.copyTo to copy ROI to a new matrix";
+      }
       data = static_cast<char *>(malloc(size));
       memcpy(data, mat.data, size);
       return "";

--- a/test/tests/core/Mat/Mat.test.js
+++ b/test/tests/core/Mat/Mat.test.js
@@ -323,7 +323,16 @@ describe('Mat', () => {
         expect(buf).instanceOf(Buffer).lengthOf(18);
       });
     });
-
+    
+    describe('getData after getRegion', () => {
+      it('should return buffer of with data of single channeled Mat', () => {
+        const region = matC3.getRegion(new cv.Rect(0, 0, 2, 2));
+        const buf = region.getData();
+        expect(buf).instanceOf(Buffer).lengthOf(12);
+        expect(new Uint8Array(buf)[6]).to.equal(region.getDataAsArray()[1][0][0])
+      });
+    });
+    
     describe('async', () => {
       it('should return buffer with data of single channeled Mat', (done) => {
         matC1.getDataAsync((err, buf) => {

--- a/test/tests/core/Mat/Mat.test.js
+++ b/test/tests/core/Mat/Mat.test.js
@@ -324,12 +324,10 @@ describe('Mat', () => {
       });
     });
     
-    describe('getData after getRegion', () => {
+    describe('getData after getRegion should throw an error', () => {
       it('should return buffer of with data of single channeled Mat', () => {
         const region = matC3.getRegion(new cv.Rect(0, 0, 2, 2));
-        const buf = region.getData();
-        expect(buf).instanceOf(Buffer).lengthOf(12);
-        expect(new Uint8Array(buf)[6]).to.equal(region.getDataAsArray()[1][0][0])
+        assertError(() => region.getData(), "Mat::GetData - Cannot call GetData when Region of Interest is defined (i.e. after getRegion) use matrix.copyTo to copy ROI to a new matrix")
       });
     });
     


### PR DESCRIPTION
This is about #480 

In GetData, detect when ROI is defined (using `locateROI`) and raise an error when it is defined.
