### PR TITLE
Update BFMatcher.d.ts

### DIFF
--- a/lib/typings/BFMatcher.d.ts
+++ b/lib/typings/BFMatcher.d.ts
@@ -6,6 +6,6 @@ export class BFMatcher {
     constructor(params: { normType: number, crossCheck?: boolean });
     match(descriptors1: Mat, descriptors2: Mat): DescriptorMatch[];
     matchAsync(descriptors1: Mat, descriptors2: Mat): Promise<DescriptorMatch[]>;
-    knnMatch(descriptors1: Mat, descriptors2: Mat, k: number): Array<[DescriptorMatch]|[]>;
-    knnMatchAsync(descriptors1: Mat, descriptors2: Mat, k: number): Promise<Array<[DescriptorMatch]|[]>>;
+    knnMatch(descriptors1: Mat, descriptors2: Mat, k: number): Array<[DescriptorMatch]|[any]>;
+    knnMatchAsync(descriptors1: Mat, descriptors2: Mat, k: number): Promise<Array<[DescriptorMatch]|[any]>>;
 }


### PR DESCRIPTION
Resolve error message: 'A tuple type element list cannot be empty.'