### PR TITLE
Tracking kcf detect tresh

### DIFF
--- a/cc/modules/tracking/Trackers/TrackerKCFParams.cc
+++ b/cc/modules/tracking/Trackers/TrackerKCFParams.cc
@@ -19,6 +19,7 @@ NAN_MODULE_INIT(TrackerKCFParams::Init) {
 	Nan::SetAccessor(instanceTemplate, FF_NEW_STRING("interp_factor"), interp_factorGet, interp_factorSet);
 	Nan::SetAccessor(instanceTemplate, FF_NEW_STRING("output_sigma_factor"), output_sigma_factorGet, output_sigma_factorSet);
 	Nan::SetAccessor(instanceTemplate, FF_NEW_STRING("pca_learning_rate"), pca_learning_rateGet, pca_learning_rateSet);
+	Nan::SetAccessor(instanceTemplate, FF_NEW_STRING("detect_thresh"), detect_threshGet, detect_threshSet);
 	Nan::SetAccessor(instanceTemplate, FF_NEW_STRING("resize"), resizeGet, resizeSet);
 	Nan::SetAccessor(instanceTemplate, FF_NEW_STRING("split_coeff"), split_coeffGet, split_coeffSet);
 	Nan::SetAccessor(instanceTemplate, FF_NEW_STRING("wrap_kernel"), wrap_kernelGet, wrap_kernelSet);

--- a/cc/modules/tracking/Trackers/TrackerKCFParams.cc
+++ b/cc/modules/tracking/Trackers/TrackerKCFParams.cc
@@ -19,7 +19,6 @@ NAN_MODULE_INIT(TrackerKCFParams::Init) {
 	Nan::SetAccessor(instanceTemplate, FF_NEW_STRING("interp_factor"), interp_factorGet, interp_factorSet);
 	Nan::SetAccessor(instanceTemplate, FF_NEW_STRING("output_sigma_factor"), output_sigma_factorGet, output_sigma_factorSet);
 	Nan::SetAccessor(instanceTemplate, FF_NEW_STRING("pca_learning_rate"), pca_learning_rateGet, pca_learning_rateSet);
-	Nan::SetAccessor(instanceTemplate, FF_NEW_STRING("detect_thresh"), detect_threshGet, detect_threshSet);
 	Nan::SetAccessor(instanceTemplate, FF_NEW_STRING("resize"), resizeGet, resizeSet);
 	Nan::SetAccessor(instanceTemplate, FF_NEW_STRING("split_coeff"), split_coeffGet, split_coeffSet);
 	Nan::SetAccessor(instanceTemplate, FF_NEW_STRING("wrap_kernel"), wrap_kernelGet, wrap_kernelSet);
@@ -28,7 +27,9 @@ NAN_MODULE_INIT(TrackerKCFParams::Init) {
 	Nan::SetAccessor(instanceTemplate, FF_NEW_STRING("compressed_size"), compressed_sizeGet, compressed_sizeSet);
 	Nan::SetAccessor(instanceTemplate, FF_NEW_STRING("desc_pca"), desc_pcaGet, desc_pcaSet);
 	Nan::SetAccessor(instanceTemplate, FF_NEW_STRING("desc_npca"), desc_npcaGet, desc_npcaSet);
-
+#if CV_MINOR_VERSION > 2
+	Nan::SetAccessor(instanceTemplate, FF_NEW_STRING("detect_thresh"), detect_threshGet, detect_threshSet);
+#endif
 	target->Set(FF_NEW_STRING("TrackerKCFParams"), ctor->GetFunction());
 };
 

--- a/cc/modules/tracking/Trackers/TrackerKCFParams.h
+++ b/cc/modules/tracking/Trackers/TrackerKCFParams.h
@@ -23,8 +23,7 @@ public:
 	static FF_SETTER_NUMBER(TrackerKCFParams, output_sigma_factor, params.output_sigma_factor);
 	static FF_GETTER(TrackerKCFParams, pca_learning_rateGet, params.pca_learning_rate);
 	static FF_SETTER_NUMBER(TrackerKCFParams, pca_learning_rate, params.pca_learning_rate);
-	static FF_GETTER(TrackerKCFParams, detect_threshGet, params.detect_thresh);
-	static FF_SETTER_NUMBER(TrackerKCFParams, detect_thresh, params.detect_thresh);
+
 	static FF_GETTER(TrackerKCFParams, resizeGet, params.resize);
 	static FF_SETTER_BOOL(TrackerKCFParams, resize, params.resize);
 	static FF_GETTER(TrackerKCFParams, split_coeffGet, params.split_coeff);
@@ -41,6 +40,11 @@ public:
 	static FF_SETTER_UINT(TrackerKCFParams, desc_pca, params.desc_pca);
 	static FF_GETTER(TrackerKCFParams, desc_npcaGet, params.desc_npca);
 	static FF_SETTER_UINT(TrackerKCFParams, desc_npca, params.desc_npca);
+	
+#if CV_MINOR_VERSION > 2
+	static FF_GETTER(TrackerKCFParams, detect_threshGet, params.detect_thresh);
+	static FF_SETTER_NUMBER(TrackerKCFParams, detect_thresh, params.detect_thresh);
+#endif
 
 	static Nan::Persistent<v8::FunctionTemplate> constructor;
 };

--- a/cc/modules/tracking/Trackers/TrackerKCFParams.h
+++ b/cc/modules/tracking/Trackers/TrackerKCFParams.h
@@ -23,6 +23,8 @@ public:
 	static FF_SETTER_NUMBER(TrackerKCFParams, output_sigma_factor, params.output_sigma_factor);
 	static FF_GETTER(TrackerKCFParams, pca_learning_rateGet, params.pca_learning_rate);
 	static FF_SETTER_NUMBER(TrackerKCFParams, pca_learning_rate, params.pca_learning_rate);
+	static FF_GETTER(TrackerKCFParams, detect_threshGet, params.detect_thresh);
+	static FF_SETTER_NUMBER(TrackerKCFParams, detect_thresh, params.detect_thresh);
 	static FF_GETTER(TrackerKCFParams, resizeGet, params.resize);
 	static FF_SETTER_BOOL(TrackerKCFParams, resize, params.resize);
 	static FF_GETTER(TrackerKCFParams, split_coeffGet, params.split_coeff);

--- a/lib/typings/TrackerKCFParams.d.ts
+++ b/lib/typings/TrackerKCFParams.d.ts
@@ -12,5 +12,6 @@ export class TrackerKCFParams {
   readonly compressed_size: number;
   readonly desc_pca: number;
   readonly desc_npca: number;
+  readonly detect_thresh: number;
   constructor();
 }

--- a/test/tests/modules/tracking/trackerParamTests.js
+++ b/test/tests/modules/tracking/trackerParamTests.js
@@ -32,6 +32,7 @@ module.exports = () => {
         compress_feature: false,
         max_patch_size: 64,
         compressed_size: 32,
+        detect_thresh: 0.5,
         desc_pca: cv.trackerKCFModes.GRAY,
         desc_npca: cv.trackerKCFModes.CN
 


### PR DESCRIPTION
Adding `detect_tresh` in KCF Params (see https://docs.opencv.org/3.4/db/dd1/structcv_1_1TrackerKCF_1_1Params.html#af7c297a918719441a448181626488eb0)