### PR TITLE
WIP: Cuda Bindings

### DIFF
--- a/cc/core/core.cc
+++ b/cc/core/core.cc
@@ -45,6 +45,15 @@ NAN_MODULE_INIT(Core::Init) {
   Nan::SetMethod(target, "getNumThreads", GetNumThreads);
   Nan::SetMethod(target, "setNumThreads", SetNumThreads);
   Nan::SetMethod(target, "getThreadNum", GetThreadNum);
+
+  // CUDA core
+  // Nan::SetMethod(target, "deviceSupports", DeviceSupports);
+  Nan::SetMethod(target, "getCudaEnabledDeviceCount", GetCudaEnabledDeviceCount);
+  Nan::SetMethod(target, "getDevice", GetDevice);
+  Nan::SetMethod(target, "printCudaDeviceInfo", PrintCudaDeviceInfo);
+  Nan::SetMethod(target, "printShortCudaDeviceInfo", PrintShortCudaDeviceInfo);
+  Nan::SetMethod(target, "resetDevice", ResetDevice);
+  Nan::SetMethod(target, "setDevice", SetDevice);
 };
 
 NAN_METHOD(Core::GetBuildInformation) {
@@ -227,4 +236,62 @@ NAN_METHOD(Core::SetNumThreads) {
 NAN_METHOD(Core::GetThreadNum) {
   FF_METHOD_CONTEXT("Core::GetNumThreads");
   FF_RETURN(IntConverter::wrap(cv::getThreadNum()));
+}
+
+// CUDA core
+// NAN_METHOD(Core::DeviceSupports) {
+//   FF_METHOD_CONTEXT("Core::DeviceSupports");
+//   FF_ARG_INT(1, int featureSet);
+//   FF_RETURN(BoolConverter::wrap(cv::cuda::deviceSupports(featureSet)))
+// }
+
+NAN_METHOD(Core::GetCudaEnabledDeviceCount) {
+  FF_METHOD_CONTEXT("Core::GetCudaEnabledDeviceCount");
+  FF_RETURN(IntConverter::wrap(cv::cuda::getCudaEnabledDeviceCount()));
+}
+
+NAN_METHOD(Core::GetDevice) {
+  FF_METHOD_CONTEXT("Core::GetDevice");
+  FF_RETURN(IntConverter::wrap(cv::cuda::getDevice()));
+}
+
+NAN_METHOD(Core::PrintCudaDeviceInfo) {
+  FF_METHOD_CONTEXT("Core::PrintCudaDeviceInfo");
+  //FF_ARG_INT(0, int device);
+
+  if (!FF_IS_INT(info[0])) {
+    return Nan::ThrowError("Core::PrintCudaDeviceInfo expected arg0 to an int");
+  }
+
+  int32_t deviceNum = FF_CAST_INT(info[0]);
+  cv::cuda::printCudaDeviceInfo(deviceNum);
+}
+
+NAN_METHOD(Core::PrintShortCudaDeviceInfo) {
+  FF_METHOD_CONTEXT("Core::PrintShortCudaDeviceInfo");
+  //FF_ARG_INT(0, int device);
+
+  if (!FF_IS_INT(info[0])) {
+    return Nan::ThrowError("Core::PrintShortCudaDeviceInfo expected arg0 to an int");
+  }
+
+  int32_t deviceNum = FF_CAST_INT(info[0]);
+  cv::cuda::printCudaDeviceInfo(deviceNum);
+}
+
+NAN_METHOD(Core::ResetDevice) {
+    FF_METHOD_CONTEXT("Cuda::ResetDevice");
+    cv::cuda::resetDevice();
+}
+
+NAN_METHOD(Core::SetDevice) {
+  FF_METHOD_CONTEXT("Core::SetDevice");
+  //FF_ARG_INT(0, int device);
+
+  if (!FF_IS_INT(info[0])) {
+    return Nan::ThrowError("Core::SetDevice expected arg0 to an int");
+  }
+
+  int32_t deviceNum = FF_CAST_INT(info[0]);
+  cv::cuda::setDevice(deviceNum);
 }

--- a/cc/core/core.h
+++ b/cc/core/core.h
@@ -7,6 +7,7 @@
 #include "TermCriteria.h"
 #include "macros.h"
 #include <opencv2/core.hpp>
+#include <opencv2/core/cuda.hpp>
 
 #ifndef __FF_CORE_H__
 #define __FF_CORE_H__
@@ -25,6 +26,15 @@ public:
 	static NAN_METHOD(GetNumThreads);
 	static NAN_METHOD(SetNumThreads);
 	static NAN_METHOD(GetThreadNum);
+
+	// CUDA core
+	// static NAN_METHOD(DeviceSupports);
+    static NAN_METHOD(GetCudaEnabledDeviceCount);
+    static NAN_METHOD(GetDevice);
+    static NAN_METHOD(PrintCudaDeviceInfo);
+    static NAN_METHOD(PrintShortCudaDeviceInfo);
+    static NAN_METHOD(ResetDevice);
+    static NAN_METHOD(SetDevice);
 };
 
 #endif

--- a/lib/typings/cv.d.ts
+++ b/lib/typings/cv.d.ts
@@ -168,3 +168,13 @@ export function isCustomMatAllocatorEnabled(): boolean;
 export function dangerousEnableCustomMatAllocator(): boolean;
 export function dangerousDisableCustomMatAllocator(): boolean;
 export function getMemMetrics(): { TotalAlloc: number, TotalKnownByJS: number, NumAllocations: number, NumDeAllocations: number };
+
+// CUDA core
+// export const featureSet = FeatureSet;
+// export function deviceSupports(featureSet: number) : boolean;
+export function getCudaEnabledDeviceCount() : number;
+export function getDevice() : number;
+export function printCudaDeviceInfo(device: number) : void;
+export function printShortCudaDeviceInfo(device: number) : void;
+export function resetDevice() : void;
+export function setDevice(device: number) : void;

--- a/test/tests/core/core.test.js
+++ b/test/tests/core/core.test.js
@@ -290,3 +290,151 @@ describe('core', () => {
     })
   }
 });
+
+describe('core - cuda', () => {
+  // describe('deviceSupports', () => {
+  //   it('should have function deviceSupports', () => {
+  //     expect(cv).to.have.property('deviceSupports').to.be.a('function');
+  //   });
+
+  //   it('should have access to featureSet enum', () => {
+  //     expect(cv).to.have.property('featureSet').to.be.an('object');
+  //   });
+
+  //   generateAPITests({
+  //     getDut: () => cv,
+  //     methodName: 'deviceSupports',
+  //     hasAsync: false,
+  //     getRequiredArgs: () => ([
+  //       cv.featureSet.FEATURE_SET_COMPUTE_10,
+  //     ]),
+  //     expectOutput: res => expect(res).to.be.a('boolean'),
+  //   });
+  // });
+
+  describe('getCudaEnabledDeviceCount', () => {
+    it('should have function getCudaEnabledDeviceCount', () => {
+      expect(cv).to.have.property('getCudaEnabledDeviceCount').to.be.a('function');
+    });
+
+    generateAPITests({
+      getDut: () => cv,
+      methodName: 'getCudaEnabledDeviceCount',
+      hasAsync: false,
+      expectOutput: res => expect(res).to.be.a('number'), 
+    });
+  });
+
+  describe('getDevice', () => {
+    it('should have function getDevice', () => {
+      expect(cv).to.have.property('getDevice').to.be.a('function');
+    });
+
+    generateAPITests({
+      getDut: () => cv,
+      methodName: 'getDevice',
+      hasAsync: false,
+      expectOutput: res => expect(res).to.be.a('number'), 
+    });
+  });
+
+  describe('printCudaDeviceInfo', () => {
+    it('should have function printCudaDeviceInfo', () => {
+      expect(cv).to.have.property('printCudaDeviceInfo').to.be.a('function');
+    });
+
+    it('should try to print info for device number', () => {
+      const device = 1;
+      cv.printCudaDeviceInfo(device);
+    });
+
+    it('should throw when the argument is not integer', () => {
+      let err;
+      const expectError = (fn, msg) => {
+        try {
+          fn();
+        } catch (e) {
+          err = e;
+        }
+
+        expect(err.message).to.be.equal(msg);
+      };
+
+      expectError(() => cv.printCudaDeviceInfo('hello'),
+        'Core::PrintCudaDeviceInfo expected arg0 to an int');
+      expectError(() => cv.printCudaDeviceInfo(1.1),
+        'Core::PrintCudaDeviceInfo expected arg0 to an int');
+    });
+  });
+
+  describe('printShortCudaDeviceInfo', () => {
+    it('should have function printShortCudaDeviceInfo', () => {
+      expect(cv).to.have.property('printShortCudaDeviceInfo').to.be.a('function');
+    });
+    
+    it('should try to print short info for device number', () => {
+      const device = 1;
+      cv.printShortCudaDeviceInfo(device);
+    });
+
+    it('should throw when the argument is not integer', () => {
+      let err;
+      const expectError = (fn, msg) => {
+        try {
+          fn();
+        } catch (e) {
+          err = e;
+        }
+
+        expect(err.message).to.be.equal(msg);
+      };
+
+      expectError(() => cv.printShortCudaDeviceInfo('hello'),
+        'Core::PrintShortCudaDeviceInfo expected arg0 to an int');
+      expectError(() => cv.printShortCudaDeviceInfo(1.1),
+        'Core::PrintShortCudaDeviceInfo expected arg0 to an int');
+    });
+  });
+
+  describe('resetDevice', () => {
+    it('should have function resetDevice', () => {
+      expect(cv).to.have.property('resetDevice').to.be.a('function');
+    });
+
+    generateAPITests({
+      getDut: () => cv,
+      methodName: 'resetDevice',
+      hasAsync: false,
+      expectOutput: () => {}, 
+    });
+  });
+
+  describe('setDevice', () => {
+    it('should have function setDevice', () => {
+      expect(cv).to.have.property('setDevice').to.be.a('function');
+    });
+
+    it('should try to set device to device number', () => {
+      const device = 0;
+      cv.setDevice(device);
+    });
+
+    it('should throw when the argument is not integer', () => {
+      let err;
+      const expectError = (fn, msg) => {
+        try {
+          fn();
+        } catch (e) {
+          err = e;
+        }
+
+        expect(err.message).to.be.equal(msg);
+      };
+
+      expectError(() => cv.setDevice('hello'),
+        'Core::SetDevice expected arg0 to an int');
+      expectError(() => cv.setDevice(1.1),
+        'Core::SetDevice expected arg0 to an int');
+    });
+  });
+});


### PR DESCRIPTION
I started the implementation of the Cuda bindings by implementing the bindings described [here](https://docs.opencv.org/3.4/d8/d40/group__cudacore__init.html#ga776cf8e0301b18e19be4782754274fe0). this**PR is a work in progress SO DON'T MERGE YET**, but just so you can follow along and give some input if needed. 

Can you review this small part & tell me if there could be any improvements? 

To start, I already have 2 questions:

1. I was wondering why the generateAPITests isn't working on the functions I have to pass an argument in. The test fails because a wrong exception is thrown, although the argument is a required int. The test only succeeds if I write a manual test and set the binding in core.cc also manually instead of using FF_ARG_INT. Any idea?

2. I didn't implement deviceSupports yet because it's a bit unclear to me how I should handle enums ([FeatureSet](https://docs.opencv.org/3.4/d8/d40/group__cudacore__init.html#ga776cf8e0301b18e19be4782754274fe0) in this case). I took a look @ TermCriteria, but I still don't get it fully because that one has a constructor but FeatureSet doesn't seem to have a ctor.

Cheers!  