### PR TITLE
Use all available core for node-gyp build

### DIFF
--- a/package.json
+++ b/package.json
@@ -29,12 +29,12 @@
   "main": "./lib/opencv4nodejs.js",
   "typings": "./lib/index.d.ts",
   "scripts": {
-    "install": "node-gyp rebuild",
+    "install": "node-gyp rebuild --jobs max",
     "configure": "node-gyp configure",
-    "build": "node-gyp configure build",
-    "rebuild": "node-gyp rebuild",
+    "build": "node-gyp configure build --jobs max",
+    "rebuild": "node-gyp rebuild --jobs max",
     "clean": "node-gyp clean",
-    "build-debug": "node-gyp rebuild --debug"
+    "build-debug": "node-gyp rebuild --debug --jobs max"
   },
   "gypfile": true,
   "dependencies": {


### PR DESCRIPTION
Currently the build process uses all cores and 100% of available CPU when building OpenCV itself, and then drops to a single core when it hits `node-gyp` because that uses a single core by default. This PR simply tells `node-gyp` to use all available cores when building. I saw a 20% decrease in build time from this, and I expect the CI builds will show something similar for this PR.