### PR TITLE
Fix not found error when running on windows

### DIFF
--- a/lib/opencv4nodejs.js
+++ b/lib/opencv4nodejs.js
@@ -2,10 +2,8 @@ const promisify = require('./promisify');
 const extendWithJsSources = require('./src');
 
 const isElectronWebpack =
-  // assume module required by webpack if no system path inv envs
-  !process.env.path
   // detect if electron https://github.com/electron/electron/issues/2288
-  && global.window && global.window.process && global.window.process.type
+  global.window && global.window.process && global.window.process.type
   && global.navigator && ((global.navigator.userAgent || '').toLowerCase().indexOf(' electron/') > -1)
 
 let cv = isElectronWebpack ? require('../build/Release/opencv4nodejs.node') : require('./cv')


### PR DESCRIPTION
`process.env.path` will always be `true` which will make the flag `isElectronWebpack` always `false`