### PR TITLE
opencv-build as a peer dependency

### DIFF
--- a/README.md
+++ b/README.md
@@ -94,8 +94,17 @@ Check out <a href="https://medium.com/@muehler.v/machine-learning-with-opencv-an
 
 # How to install
 
+## With OpenCV already installed on your system
+
 ``` bash
-npm install --save opencv4nodejs
+npm install opencv4nodejs
+```
+
+## Automatically build OpenCV as a peer dependency
+
+``` bash
+npm install opencv-build
+npm install opencv4nodejs
 ```
 
 Native node modules are built via node-gyp, which already comes with npm by default. However, node-gyp requires you to have python installed. If you are running into node-gyp specific issues have a look at known issues with [node-gyp](https://github.com/nodejs/node-gyp) first.
@@ -106,17 +115,6 @@ On Windows you will furthermore need Windows Build Tools to compile OpenCV and o
 
 ``` bash
 npm install --global windows-build-tools
-```
-
-## Installing OpenCV Manually
-
-Setting up OpenCV on your own will require you to set an environment variable to prevent the auto build script to run:
-
-``` bash
-# linux and osx:
-export OPENCV4NODEJS_DISABLE_AUTOBUILD=1
-# on windows:
-set OPENCV4NODEJS_DISABLE_AUTOBUILD=1
 ```
 
 ### Windows

--- a/lib/commons.js
+++ b/lib/commons.js
@@ -1,6 +1,47 @@
 const fs = require('fs');
 const path = require('path');
 
+var opencvBuild = null;
+try {
+  opencvBuild = require('opencv-build');
+} catch (e) {
+  if (e.code !== 'MODULE_NOT_FOUND') {
+    throw e;
+  }
+
+  function isWin() {
+      return process.platform == 'win32';
+  }
+  function isOSX() {
+      return process.platform == 'darwin';
+  }
+  var opencvModules = [
+      'core',
+      'highgui',
+      'imgcodecs',
+      'imgproc',
+      'features2d',
+      'calib3d',
+      'photo',
+      'objdetect',
+      'ml',
+      'video',
+      'videoio',
+      'videostab',
+      'dnn',
+      'face',
+      'text',
+      'tracking',
+      'xfeatures2d',
+      'ximgproc'
+  ];
+
+  opencvBuild = {
+    getLibs: require('./getLibsFactory').getLibsFactory({ isWin, isOSX, opencvModules, path, fs }),
+    isAutoBuildDisabled: () => true,
+  }
+}
+
 function resolvePath(filePath, file) {
   if (!filePath) {
     return undefined;
@@ -21,6 +62,7 @@ function getLibDir() {
 }
 
 module.exports = {
+  opencvBuild,
   resolvePath,
   defaultDir,
   defaultIncludeDir,

--- a/lib/cv.js
+++ b/lib/cv.js
@@ -1,6 +1,5 @@
 const path = require('path');
-const opencvBuild = require('opencv-build');
-const { resolvePath } = require('./commons');
+const { resolvePath, opencvBuild } = require('./commons');
 
 // ensure binaries are added to path on windows
 if (!opencvBuild.isAutoBuildDisabled() && process.platform === 'win32') {

--- a/lib/defines.js
+++ b/lib/defines.js
@@ -1,5 +1,4 @@
-const opencvBuild = require('opencv-build');
-const { getLibDir } = require('./commons');
+const { getLibDir, opencvBuild } = require('./commons');
 
 if (opencvBuild.isAutoBuildDisabled()) {
   opencvBuild.getLibs(getLibDir())

--- a/lib/getLibsFactory.js
+++ b/lib/getLibsFactory.js
@@ -1,0 +1,45 @@
+var worldModule = 'world';
+function getLibsFactory(args) {
+    var opencvModules = args.opencvModules, isWin = args.isWin, isOSX = args.isOSX, fs = args.fs, path = args.path;
+    function getLibPrefix() {
+        return isWin() ? 'opencv_' : 'libopencv_';
+    }
+    function getLibSuffix() {
+        return isWin() ? 'lib' : (isOSX() ? 'dylib' : 'so');
+    }
+    function getLibNameRegex(opencvModuleName) {
+        return new RegExp("^" + getLibPrefix() + opencvModuleName + "[0-9]{0,3}." + getLibSuffix() + "$");
+    }
+    function createLibResolver(libDir) {
+        function getLibAbsPath(libFile) {
+            return (libFile
+                ? fs.realpathSync(path.resolve(libDir, libFile))
+                : undefined);
+        }
+        function matchLibName(libFile, opencvModuleName) {
+            return !!(libFile.match(getLibNameRegex(opencvModuleName)) || [])[0];
+        }
+        var libFiles = fs.readdirSync(libDir);
+        return function (opencvModuleName) {
+            return getLibAbsPath(libFiles.find(function (libFile) { return matchLibName(libFile, opencvModuleName); }));
+        };
+    }
+    return function (libDir) {
+        if (!fs.existsSync(libDir)) {
+            throw new Error("specified lib dir does not exist: " + libDir);
+        }
+        var resolveLib = createLibResolver(libDir);
+        var worldLibPath = resolveLib(worldModule);
+        if (worldLibPath) {
+            return [{
+                    opencvModule: worldModule,
+                    libPath: worldLibPath
+                }];
+        }
+        return opencvModules.map(function (opencvModule) { return ({
+            opencvModule: opencvModule,
+            libPath: resolveLib(opencvModule)
+        }); });
+    };
+}
+exports.getLibsFactory = getLibsFactory;

--- a/lib/includes.js
+++ b/lib/includes.js
@@ -1,5 +1,4 @@
-const opencvBuild = require('opencv-build');
-const { resolvePath, defaultIncludeDir, defaultIncludeDirOpenCV4 } = require('./commons');
+const { resolvePath, defaultIncludeDir, defaultIncludeDirOpenCV4, opencvBuild } = require('./commons');
 
 if (opencvBuild.isAutoBuildDisabled()) {
   const explicitIncludeDir = resolvePath(process.env.OPENCV_INCLUDE_DIR);

--- a/lib/libs.js
+++ b/lib/libs.js
@@ -1,5 +1,4 @@
-const opencvBuild = require('opencv-build');
-const { resolvePath, getLibDir } = require('./commons');
+const { resolvePath, getLibDir, opencvBuild } = require('./commons');
 
 function linkLibs(libs) {
   libs

--- a/package.json
+++ b/package.json
@@ -39,8 +39,7 @@
   "gypfile": true,
   "dependencies": {
     "nan": "^2.14.0",
-    "native-node-utils": "^0.2.7",
-    "opencv-build": "^0.1.5"
+    "native-node-utils": "^0.2.7"
   },
   "optionalDependencies": {
     "@types/node": ">6"


### PR DESCRIPTION
Instead of relying on the OPENCV4NODEJS_DISABLE_AUTOBUILD environment variable, a user could choose to auto build by installing opencv-build along with opencv4nodejs:

```
npm i opencv-build
npm i opencv4nodejs
```
