### PR TITLE
Corrected the keypoint typescript definition

### DIFF
--- a/lib/typings/KeyPoint.d.ts
+++ b/lib/typings/KeyPoint.d.ts
@@ -1,7 +1,7 @@
 import { Point2 } from './Point2.d';
 
 export class KeyPoint {
-  readonly point: Point2;
+  readonly pt: Point2;
   readonly size: number;
   readonly angle: number;
   readonly response: number;


### PR DESCRIPTION
The definition of keypoint uses `pt` instead of `point`.   

See here:    
https://github.com/justadudewhohacks/opencv4nodejs/blob/02be3b6416b8225efca4d564d64d5db71372babd/cc/features2d/KeyPoint.cc