### PR TITLE
Fix SplitChannelsAsync

### DIFF
--- a/cc/core/Mat.cc
+++ b/cc/core/Mat.cc
@@ -80,7 +80,7 @@ NAN_MODULE_INIT(Mat::Init) {
   Nan::SetPrototypeMethod(ctor, "copyMakeBorder", CopyMakeBorder);
   Nan::SetPrototypeMethod(ctor, "copyMakeBorderAsync", CopyMakeBorderAsync);
   Nan::SetPrototypeMethod(ctor, "splitChannels", Split);
-  Nan::SetPrototypeMethod(ctor, "splitChannelsAsync", Split);
+  Nan::SetPrototypeMethod(ctor, "splitChannelsAsync", SplitAsync);
 
 #if CV_VERSION_GREATER_EQUAL(3, 2, 0)
   Nan::SetPrototypeMethod(ctor, "rotate", Rotate);


### PR DESCRIPTION
Whenever I called splitChannelsAsync my application would crash silently.
I have not tested this change, but I suspect it will fix the problem.