### PR TITLE
Update Mat.drawContours-typing

### DIFF
--- a/lib/typings/Mat.d.ts
+++ b/lib/typings/Mat.d.ts
@@ -132,7 +132,7 @@ export class Mat {
   drawChessboardCorners(patternSize: Size, corners: Point2[], patternWasFound: boolean): void;
   drawChessboardCornersAsync(patternSize: Size, corners: Point2[], patternWasFound: boolean): Promise<void>;
   drawCircle(center: Point2, radius: number, color?: Vec3, thickness?: number, lineType?: number, shift?: number): void;
-  drawContours(contours: Contour[], color: Vec3, contourIdx?: number, maxLevel?: number, offset?: Point2, lineType?: number, thickness?: number, shift?: number): void;
+  drawContours(contours: Point2[], countourIdx: number, color: Vec3, maxLevel?: number, offset?: Point2, lineType?: number, thickness?: number, shift?: number): void;
   drawEllipse(box: RotatedRect, color?: Vec3, thickness?: number, lineType?: number): void;
   drawEllipse(center: Point2, axes: Size, angle: number, startAngle: number, endAngle: number, color?: Vec3, thickness?: number, lineType?: number, shift?: number): void;
   drawFillConvexPoly(pts: Point2[], color?: Vec3, lineType?: number, shift?: number): void;


### PR DESCRIPTION
Resolves https://github.com/justadudewhohacks/opencv4nodejs/issues/691.

I would prefer for the actual method to accept contours instead of updating the type to correctly state `Point2[]` as the input, but wrong typings are quite misleading and easy to fix.

Please tell me if the proposed type still is wrong, it is based on the linked issue as well as personal usage, but I might have missed something and could gladly update it.
