### PR TITLE
Added Opencv DNN Net Backend and Target change

### DIFF
--- a/cc/dnn/Net.cc
+++ b/cc/dnn/Net.cc
@@ -43,12 +43,12 @@ NAN_MODULE_INIT(Net::Init) {
 	// DNN_BACKEND_CUDA
 
   
-  FF_SET_JS_PROP(target, DNN_BACKEND_DEFAULT, Nan::New<v8::Integer>(cv::dnn::DNN_BACKEND_DEFAULT));
-  FF_SET_JS_PROP(target, DNN_BACKEND_HALIDE, Nan::New<v8::Integer>(cv::dnn::DNN_BACKEND_HALIDE));
-  FF_SET_JS_PROP(target, DNN_BACKEND_INFERENCE_ENGINE, Nan::New<v8::Integer>(cv::dnn::DNN_BACKEND_INFERENCE_ENGINE));
-  FF_SET_JS_PROP(target, DNN_BACKEND_OPENCV, Nan::New<v8::Integer>(cv::dnn::DNN_BACKEND_OPENCV));
-  FF_SET_JS_PROP(target, DNN_BACKEND_VKCOM, Nan::New<v8::Integer>(cv::dnn::DNN_BACKEND_VKCOM));
-  FF_SET_JS_PROP(target, DNN_BACKEND_CUDA, Nan::New<v8::Integer>(cv::dnn::DNN_BACKEND_CUDA));
+  FF_SET_JS_PROP(target, DNN_BACKEND_DEFAULT, Nan::New<v8::Integer>(cv::dnn::Backend::DNN_BACKEND_DEFAULT));
+  FF_SET_JS_PROP(target, DNN_BACKEND_HALIDE, Nan::New<v8::Integer>(cv::dnn::Backend::DNN_BACKEND_HALIDE));
+  FF_SET_JS_PROP(target, DNN_BACKEND_INFERENCE_ENGINE, Nan::New<v8::Integer>(cv::dnn::Backend::DNN_BACKEND_INFERENCE_ENGINE));
+  FF_SET_JS_PROP(target, DNN_BACKEND_OPENCV, Nan::New<v8::Integer>(cv::dnn::Backend::DNN_BACKEND_OPENCV));
+  FF_SET_JS_PROP(target, DNN_BACKEND_VKCOM, Nan::New<v8::Integer>(cv::dnn::Backend::DNN_BACKEND_VKCOM));
+  FF_SET_JS_PROP(target, DNN_BACKEND_CUDA, Nan::New<v8::Integer>(cv::dnn::Backend::DNN_BACKEND_CUDA));
 
 
   // DNN_TARGET_CPU = 0,
@@ -60,14 +60,14 @@ NAN_MODULE_INIT(Net::Init) {
   // DNN_TARGET_CUDA,
   // DNN_TARGET_CUDA_FP16
 
-  FF_SET_JS_PROP(target, DNN_TARGET_CPU, Nan::New<v8::Integer>(cv::dnn::DNN_TARGET_CPU));
-  FF_SET_JS_PROP(target, DNN_TARGET_OPENCL, Nan::New<v8::Integer>(cv::dnn::DNN_TARGET_OPENCL));
-  FF_SET_JS_PROP(target, DNN_TARGET_OPENCL_FP16, Nan::New<v8::Integer>(cv::dnn::DNN_TARGET_OPENCL_FP16));
-  FF_SET_JS_PROP(target, DNN_TARGET_MYRIAD, Nan::New<v8::Integer>(cv::dnn::DNN_TARGET_MYRIAD));
-  FF_SET_JS_PROP(target, DNN_TARGET_VULKAN, Nan::New<v8::Integer>(cv::dnn::DNN_TARGET_VULKAN));
-  FF_SET_JS_PROP(target, DNN_TARGET_FPGA, Nan::New<v8::Integer>(cv::dnn::DNN_TARGET_FPGA));
-  FF_SET_JS_PROP(target, DNN_TARGET_CUDA, Nan::New<v8::Integer>(cv::dnn::DNN_TARGET_CUDA));
-  FF_SET_JS_PROP(target, DNN_TARGET_CUDA_FP16, Nan::New<v8::Integer>(cv::dnn::DNN_TARGET_CUDA_FP16));
+  FF_SET_JS_PROP(target, DNN_TARGET_CPU, Nan::New<v8::Integer>(cv::dnn::Target::DNN_TARGET_CPU));
+  FF_SET_JS_PROP(target, DNN_TARGET_OPENCL, Nan::New<v8::Integer>(cv::dnn::Target::DNN_TARGET_OPENCL));
+  FF_SET_JS_PROP(target, DNN_TARGET_OPENCL_FP16, Nan::New<v8::Integer>(cv::dnn::Target::DNN_TARGET_OPENCL_FP16));
+  FF_SET_JS_PROP(target, DNN_TARGET_MYRIAD, Nan::New<v8::Integer>(cv::dnn::Target::DNN_TARGET_MYRIAD));
+  FF_SET_JS_PROP(target, DNN_TARGET_VULKAN, Nan::New<v8::Integer>(cv::dnn::Target::DNN_TARGET_VULKAN));
+  FF_SET_JS_PROP(target, DNN_TARGET_FPGA, Nan::New<v8::Integer>(cv::dnn::Target::DNN_TARGET_FPGA));
+  FF_SET_JS_PROP(target, DNN_TARGET_CUDA, Nan::New<v8::Integer>(cv::dnn::Target::DNN_TARGET_CUDA));
+  FF_SET_JS_PROP(target, DNN_TARGET_CUDA_FP16, Nan::New<v8::Integer>(cv::dnn::Target::DNN_TARGET_CUDA_FP16));
   
 
 

--- a/cc/dnn/Net.cc
+++ b/cc/dnn/Net.cc
@@ -51,6 +51,29 @@ NAN_MODULE_INIT(Net::Init) {
   FF_SET_JS_PROP(target, DNN_BACKEND_CUDA, Nan::New<v8::Integer>(cv::dnn::DNN_BACKEND_CUDA));
 
 
+  // DNN_TARGET_CPU = 0,
+  // DNN_TARGET_OPENCL,
+  // DNN_TARGET_OPENCL_FP16,
+  // DNN_TARGET_MYRIAD,
+  // DNN_TARGET_VULKAN,
+  // DNN_TARGET_FPGA,  //!< FPGA device with CPU fallbacks using Inference Engine's Heterogeneous plugin.
+  // DNN_TARGET_CUDA,
+  // DNN_TARGET_CUDA_FP16
+
+  FF_SET_JS_PROP(target, DNN_TARGET_CPU, Nan::New<v8::Integer>(cv::dnn::DNN_TARGET_CPU));
+  FF_SET_JS_PROP(target, DNN_TARGET_OPENCL, Nan::New<v8::Integer>(cv::dnn::DNN_TARGET_OPENCL));
+  FF_SET_JS_PROP(target, DNN_TARGET_OPENCL_FP16, Nan::New<v8::Integer>(cv::dnn::DNN_TARGET_OPENCL_FP16));
+  FF_SET_JS_PROP(target, DNN_TARGET_MYRIAD, Nan::New<v8::Integer>(cv::dnn::DNN_TARGET_MYRIAD));
+  FF_SET_JS_PROP(target, DNN_TARGET_VULKAN, Nan::New<v8::Integer>(cv::dnn::DNN_TARGET_VULKAN));
+  FF_SET_JS_PROP(target, DNN_TARGET_FPGA, Nan::New<v8::Integer>(cv::dnn::DNN_TARGET_FPGA));
+  FF_SET_JS_PROP(target, DNN_TARGET_CUDA, Nan::New<v8::Integer>(cv::dnn::DNN_TARGET_CUDA));
+  FF_SET_JS_PROP(target, DNN_TARGET_CUDA_FP16, Nan::New<v8::Integer>(cv::dnn::DNN_TARGET_CUDA_FP16));
+  
+
+
+
+
+
   Nan::Set(target,Nan::New("Net").ToLocalChecked(), FF::getFunction(ctor));
 
 };

--- a/cc/dnn/Net.cc
+++ b/cc/dnn/Net.cc
@@ -3,10 +3,13 @@
 #ifdef HAVE_OPENCV_DNN
 
 #include "opencv2/core.hpp"
+#include "opencv2/dnn.hpp"
 #include "macros.h"
 
 #include "Net.h"
 #include "NetBindings.h"
+
+// using namespace cv::dnn;
 
 Nan::Persistent<v8::FunctionTemplate> Net::constructor;
 
@@ -29,8 +32,27 @@ NAN_MODULE_INIT(Net::Init) {
   Nan::SetPrototypeMethod(ctor, "setPreferableBackend", SetPreferableBackend);
   Nan::SetPrototypeMethod(ctor, "setPreferableTarget", SetPreferableTarget);
   
+  // DNN Backend Options
+	// ----- For now hardcoded
+	// DNN_BACKEND_DEFAULT = 0,
+	// DNN_BACKEND_HALIDE,
+	// DNN_BACKEND_INFERENCE_ENGINE,            //!< Intel's Inference Engine computational backend
+	// 											//!< @sa setInferenceEngineBackendType
+	// DNN_BACKEND_OPENCV,
+	// DNN_BACKEND_VKCOM,
+	// DNN_BACKEND_CUDA
+
+  
+  FF_SET_JS_PROP(target, DNN_BACKEND_DEFAULT, Nan::New<v8::Integer>(cv::dnn::DNN_BACKEND_DEFAULT));
+  FF_SET_JS_PROP(target, DNN_BACKEND_HALIDE, Nan::New<v8::Integer>(cv::dnn::DNN_BACKEND_HALIDE));
+  FF_SET_JS_PROP(target, DNN_BACKEND_INFERENCE_ENGINE, Nan::New<v8::Integer>(cv::dnn::DNN_BACKEND_INFERENCE_ENGINE));
+  FF_SET_JS_PROP(target, DNN_BACKEND_OPENCV, Nan::New<v8::Integer>(cv::dnn::DNN_BACKEND_OPENCV));
+  FF_SET_JS_PROP(target, DNN_BACKEND_VKCOM, Nan::New<v8::Integer>(cv::dnn::DNN_BACKEND_VKCOM));
+  FF_SET_JS_PROP(target, DNN_BACKEND_CUDA, Nan::New<v8::Integer>(cv::dnn::DNN_BACKEND_CUDA));
+
 
   Nan::Set(target,Nan::New("Net").ToLocalChecked(), FF::getFunction(ctor));
+
 };
 
 NAN_METHOD(Net::New) {
@@ -100,5 +122,26 @@ NAN_METHOD(Net::GetUnconnectedOutLayersAsync) {
       "Net::GetUnconnectedOutLayersAsync",
       info);
 }
+
+// ----------------------------------------------
+// ----------------------------------------------
+
+// Change Backend Functions
+NAN_METHOD(Net::SetPreferableBackend) {
+  FF::executeSyncBinding(
+    std::make_shared<NetBindings::SetPreferableBackendWorker>(Net::unwrapSelf(info)),
+    "Net::SetPreferableBackend",
+    info
+  );
+}
+
+NAN_METHOD(Net::SetPreferableTarget) {
+  FF::executeSyncBinding(
+    std::make_shared<NetBindings::SetPreferableTargetWorker>(Net::unwrapSelf(info)),
+    "Net::SetPreferableTarget",
+    info
+  );
+}
+
 
 #endif

--- a/cc/dnn/Net.cc
+++ b/cc/dnn/Net.cc
@@ -25,6 +25,11 @@ NAN_MODULE_INIT(Net::Init) {
   Nan::SetPrototypeMethod(ctor, "getUnconnectedOutLayers", GetUnconnectedOutLayers);
   Nan::SetPrototypeMethod(ctor, "getUnconnectedOutLayersAsync", GetUnconnectedOutLayersAsync);
 
+  // Change Backend Functions
+  Nan::SetPrototypeMethod(ctor, "setPreferableBackend", SetPreferableBackend);
+  Nan::SetPrototypeMethod(ctor, "setPreferableTarget", SetPreferableTarget);
+  
+
   Nan::Set(target,Nan::New("Net").ToLocalChecked(), FF::getFunction(ctor));
 };
 

--- a/cc/dnn/Net.h
+++ b/cc/dnn/Net.h
@@ -21,14 +21,16 @@ public:
 	static NAN_METHOD(SetInputAsync);
 	static NAN_METHOD(Forward);
 	static NAN_METHOD(ForwardAsync);
-  static NAN_METHOD(GetLayerNames);
-  static NAN_METHOD(GetLayerNamesAsync);
-  static NAN_METHOD(GetUnconnectedOutLayers);
-  static NAN_METHOD(GetUnconnectedOutLayersAsync);
+	static NAN_METHOD(GetLayerNames);
+	static NAN_METHOD(GetLayerNamesAsync);
+	static NAN_METHOD(GetUnconnectedOutLayers);
+	static NAN_METHOD(GetUnconnectedOutLayersAsync);
 
-  // Change Backend Functions
-  static NAN_METHOD(SetPreferableBackend);
-  static NAN_METHOD(SetPreferableTarget);
+	// Change Backend Functions
+	static NAN_METHOD(SetPreferableBackend);
+	static NAN_METHOD(SetPreferableTarget);
+
+
 };
 
 #endif

--- a/cc/dnn/Net.h
+++ b/cc/dnn/Net.h
@@ -25,6 +25,10 @@ public:
   static NAN_METHOD(GetLayerNamesAsync);
   static NAN_METHOD(GetUnconnectedOutLayers);
   static NAN_METHOD(GetUnconnectedOutLayersAsync);
+
+  // Change Backend Functions
+  static NAN_METHOD(SetPreferableBackend);
+  static NAN_METHOD(SetPreferableTarget);
 };
 
 #endif

--- a/cc/dnn/NetBindings.h
+++ b/cc/dnn/NetBindings.h
@@ -127,10 +127,10 @@ namespace NetBindings {
   // Change Backend Functions
 
   // SetPreferableBackend
-  struct SetPreferableBackend : public CatchCvExceptionWorker {
+  struct SetPreferableBackendWorker : public CatchCvExceptionWorker {
   public:
     cv::dnn::Net self;
-    SetPreferableBackend(cv::dnn::Net self) {
+    SetPreferableBackendWorker(cv::dnn::Net self) {
       this->self = self;
     }
 
@@ -151,10 +151,10 @@ namespace NetBindings {
 
 
   // SetPreferableTarget
-  struct SetPreferableTarget : public CatchCvExceptionWorker {
+  struct SetPreferableTargetWorker : public CatchCvExceptionWorker {
   public:
     cv::dnn::Net self;
-    SetPreferableBackend(cv::dnn::Net self) {
+    SetPreferableTargetWorker(cv::dnn::Net self) {
       this->self = self;
     }
 

--- a/cc/dnn/NetBindings.h
+++ b/cc/dnn/NetBindings.h
@@ -121,6 +121,60 @@ namespace NetBindings {
     }
   };
 
+  // ----------------------------------------------
+  // ----------------------------------------------
+
+  // Change Backend Functions
+
+  // SetPreferableBackend
+  struct SetPreferableBackend : public CatchCvExceptionWorker {
+  public:
+    cv::dnn::Net self;
+    SetPreferableBackend(cv::dnn::Net self) {
+      this->self = self;
+    }
+
+    std::size_t backend;
+
+
+    std::string executeCatchCvExceptionWorker() {
+      self.setPreferableBackend(backend);
+      return "";
+    }
+
+    bool unwrapRequiredArgs(Nan::NAN_METHOD_ARGS_TYPE info) {
+      return (
+        FF::UintConverter::arg(0, &backend, info)
+      );
+    }
+  };
+
+
+  // SetPreferableTarget
+  struct SetPreferableTarget : public CatchCvExceptionWorker {
+  public:
+    cv::dnn::Net self;
+    SetPreferableBackend(cv::dnn::Net self) {
+      this->self = self;
+    }
+
+    std::size_t backend;
+
+
+    std::string executeCatchCvExceptionWorker() {
+      self.setPreferableTarget(backend);
+      return "";
+    }
+
+    bool unwrapRequiredArgs(Nan::NAN_METHOD_ARGS_TYPE info) {
+      return (
+        FF::UintConverter::arg(0, &backend, info)
+      );
+    }
+  };
+
+
+
 }
 
 #endif

--- a/cc/dnn/NetBindings.h
+++ b/cc/dnn/NetBindings.h
@@ -134,7 +134,7 @@ namespace NetBindings {
       this->self = self;
     }
 
-    std::size_t backend;
+    int backend;
 
 
     std::string executeCatchCvExceptionWorker() {
@@ -144,7 +144,7 @@ namespace NetBindings {
 
     bool unwrapRequiredArgs(Nan::NAN_METHOD_ARGS_TYPE info) {
       return (
-        FF::UintConverter::arg(0, &backend, info)
+        FF::IntConverter::arg(0, &backend, info)
       );
     }
   };
@@ -158,7 +158,7 @@ namespace NetBindings {
       this->self = self;
     }
 
-    std::size_t backend;
+    int backend;
 
 
     std::string executeCatchCvExceptionWorker() {
@@ -168,7 +168,7 @@ namespace NetBindings {
 
     bool unwrapRequiredArgs(Nan::NAN_METHOD_ARGS_TYPE info) {
       return (
-        FF::UintConverter::arg(0, &backend, info)
+        FF::IntConverter::arg(0, &backend, info)
       );
     }
   };

--- a/lib/typings/Net.d.ts
+++ b/lib/typings/Net.d.ts
@@ -7,4 +7,9 @@ export class Net {
   forwardAsync(outBlobNames?: string[]): Promise<Mat[]>;
   setInput(blob: Mat, inputName?: string): void;
   setInputAsync(blob: Mat, inputName?: string): Promise<void>;
+
+  // Set DNN_Backend
+  setPreferableBackend(backend?: number): void;
+  setPreferableTarget(backend?: number): void;
+
 }

--- a/lib/typings/constants.d.ts
+++ b/lib/typings/constants.d.ts
@@ -611,3 +611,13 @@ export const DNN_BACKEND_INFERENCE_ENGINE: number;
 export const DNN_BACKEND_OPENCV: number;
 export const DNN_BACKEND_VKCOM: number;
 export const DNN_BACKEND_CUDA: number;
+
+// DNN Target
+export const DNN_TARGET_CPU: number;
+export const DNN_TARGET_OPENCL: number;
+export const DNN_TARGET_OPENCL_FP16: number;
+export const DNN_TARGET_MYRIAD: number;
+export const DNN_TARGET_VULKAN: number;
+export const DNN_TARGET_FPGA: number;
+export const DNN_TARGET_CUDA: number;
+export const DNN_TARGET_CUDA_FP16: number;

--- a/lib/typings/constants.d.ts
+++ b/lib/typings/constants.d.ts
@@ -602,3 +602,12 @@ export const statModel: {
   RAW_OUTPUT: number;
   UPDATE_MODEL: number;
 }
+
+
+// DNN_Backend
+export const DNN_BACKEND_DEFAULT: number;
+export const DNN_BACKEND_HALIDE: number;
+export const DNN_BACKEND_INFERENCE_ENGINE: number;
+export const DNN_BACKEND_OPENCV: number;
+export const DNN_BACKEND_VKCOM: number;
+export const DNN_BACKEND_CUDA: number;


### PR DESCRIPTION
A day ago I [asked](https://github.com/justadudewhohacks/opencv4nodejs/issues/758) for OpenCV DNN GPU support for running cv.Net in CUDA Backend. Looking in DNN Net codes, I have found that **setPreferableBackend** and **setPreferableTarget** were not ported to **opencv4nodejs**. 

So I ported these functions from  and corresponding options ( currently hard coded, but should be fine for opencv 3 or 4 ) from [dnn.hpp](https://github.com/opencv/opencv/blob/4cdb4652cfd5ed94a415dc8e161595edaea152b9/modules/dnn/include/opencv2/dnn/dnn.hpp).


Currently I was able to build opencv (4.3.0) with these flags: `-DWITH_CUDA=ON -DWITH_CUDNN=ON -DOPENCV_DNN_CUDA=ON`, and run `cv.Net` in **CUDA** backend.

All the other BACKEND and TARGET options should work just fine (have not tested), if opencv is compiled accordingly. 