### PR TITLE
add gyp flags

### DIFF
--- a/install/install.js
+++ b/install/install.js
@@ -78,7 +78,7 @@ process.env['OPENCV4NODEJS_INCLUDES'] = includes.join('\n')
 process.env['OPENCV4NODEJS_LIBRARIES'] = libs.join('\n')
 
 const debug = process.env.BINDINGS_DEBUG ? '--debug' : ''
-const flags = `${process.env.NODE_GYP_REBUILD_FLAGS.trim()} ` || ''
+const flags = (process.env.NODE_GYP_REBUILD_FLAGS && `${process.env.NODE_GYP_REBUILD_FLAGS.trim()} `) || ''
 const nodegypCmd = 'node-gyp rebuild --jobs max ' + flags + debug
 log.info('install', `spawning node gyp process: ${nodegypCmd}`)
 const child = child_process.exec(nodegypCmd, { maxBuffer: Infinity }, function(err, stdout, stderr) {

--- a/install/install.js
+++ b/install/install.js
@@ -77,8 +77,9 @@ process.env['OPENCV4NODEJS_DEFINES'] = defines.join('\n')
 process.env['OPENCV4NODEJS_INCLUDES'] = includes.join('\n')
 process.env['OPENCV4NODEJS_LIBRARIES'] = libs.join('\n')
 
-const flags = process.env.BINDINGS_DEBUG ? '--jobs max --debug' : '--jobs max'
-const nodegypCmd = 'node-gyp rebuild ' + flags
+const debug = process.env.BINDINGS_DEBUG ? '--debug' : ''
+const flags = `${process.env.NODE_GYP_REBUILD_FLAGS.trim()} ` || ''
+const nodegypCmd = 'node-gyp rebuild --jobs max ' + flags + debug
 log.info('install', `spawning node gyp process: ${nodegypCmd}`)
 const child = child_process.exec(nodegypCmd, { maxBuffer: Infinity }, function(err, stdout, stderr) {
   const _err = err || stderr


### PR DESCRIPTION
Add environment variable for parametrizing node gyp rebuild call.
Support for BINDINGS_DEBUG is left.
--jobs max flag is moved to default string.

**Pros:**

1. We are not obliged to use electron rebuild as we can just pass all the parameters via NODE_GYP_REBUILD_FLAGS.
2. Moreover, we can generally put --debug flag (and others) into NODE_GYP_REBUILD_FLAGS.
