### PR TITLE
Add BINDINGS_JOBS env var to customise node-gyp --jobs argument

### DIFF
--- a/install/install.js
+++ b/install/install.js
@@ -77,8 +77,16 @@ process.env['OPENCV4NODEJS_DEFINES'] = defines.join('\n')
 process.env['OPENCV4NODEJS_INCLUDES'] = includes.join('\n')
 process.env['OPENCV4NODEJS_LIBRARIES'] = libs.join('\n')
 
-const flags = process.env.BINDINGS_DEBUG ? '--jobs max --debug' : '--jobs max'
-const nodegypCmd = 'node-gyp rebuild ' + flags
+const flags = [];
+if (process.env.BINDINGS_JOBS) {
+  flags.push('--jobs ' + process.env.BINDINGS_JOBS);
+} else {
+  flags.push('--jobs max');
+}
+if (process.env.BINDINGS_DEBUG) {
+  flags.push('--debug');
+}
+const nodegypCmd = 'node-gyp rebuild ' + flags.join(' ')
 log.info('install', `spawning node gyp process: ${nodegypCmd}`)
 const child = child_process.exec(nodegypCmd, { maxBuffer: Infinity }, function(err, stdout, stderr) {
   const _err = err || stderr


### PR DESCRIPTION
Fixes #826 

I wanted to customise the `--jobs` argument that's passed to `node-gyp`. Currently it's always set to `--jobs max` and I want to set it to `--jobs 1`. I've added a `BINDINGS_JOBS` env var to allow it to be customised. The default is still `--jobs max`.